### PR TITLE
Refine model and views to use CodeIgniter 3 utilities

### DIFF
--- a/application/models/Cliente_model.php
+++ b/application/models/Cliente_model.php
@@ -1,8 +1,12 @@
 <?php
-class Cliente_model {
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Cliente_model extends CI_Model {
+    public function __construct() {
+        parent::__construct();
+    }
+
     public function all() {
-        return [
-            ['id' => 1, 'nome' => 'João Silva', 'email' => 'joao@email.com']
-        ];
+        return $this->db->get('clientes')->result_array();
     }
 }

--- a/application/views/adicionar_produto.php
+++ b/application/views/adicionar_produto.php
@@ -12,8 +12,8 @@
   </style>
 </head>
 <body class="d-flex min-vh-100 bg-light text-dark">
-<?php include __DIR__.'/navbar.php'; ?>
-<?php include __DIR__.'/sidebar.php'; ?>
+<?php $this->load->view('navbar'); ?>
+<?php $this->load->view('sidebar'); ?>
 <div class="content">
 <div class="container-fluid">
       <h4 class="mb-4">Adicionar Novo Produto</h4>

--- a/application/views/cadastrar.php
+++ b/application/views/cadastrar.php
@@ -12,8 +12,8 @@
   </style>
 </head>
 <body class="d-flex min-vh-100 bg-light text-dark">
-<?php include __DIR__.'/navbar.php'; ?>
-<?php include __DIR__.'/sidebar.php'; ?>
+<?php $this->load->view('navbar'); ?>
+<?php $this->load->view('sidebar'); ?>
 
   <!-- Contêiner onde a barra lateral é carregada -->
 <!-- Área principal do conteúdo -->

--- a/application/views/editar.php
+++ b/application/views/editar.php
@@ -9,8 +9,8 @@
   <link href="../../style.css" rel="stylesheet">
 </head>
 <body class="d-flex min-vh-100 bg-light text-dark">
-<?php include __DIR__.'/navbar.php'; ?>
-<?php include __DIR__.'/sidebar.php'; ?>
+<?php $this->load->view('navbar'); ?>
+<?php $this->load->view('sidebar'); ?>
 <div class="content">
 <div class="container-fluid">
       <h4 class="mb-4">Editar Cliente</h4>

--- a/application/views/editar_produto.php
+++ b/application/views/editar_produto.php
@@ -9,8 +9,8 @@
   <link href="../../style.css" rel="stylesheet">
 </head>
 <body class="d-flex min-vh-100 bg-light text-dark">
-<?php include __DIR__.'/navbar.php'; ?>
-<?php include __DIR__.'/sidebar.php'; ?>
+<?php $this->load->view('navbar'); ?>
+<?php $this->load->view('sidebar'); ?>
 <div class="content">
 <div class="container-fluid">
       <h4 class="mb-4">Editar Produto</h4>

--- a/application/views/fluxo_caixa.php
+++ b/application/views/fluxo_caixa.php
@@ -11,8 +11,8 @@
   <link href="../../style.css" rel="stylesheet">
 </head>
 <body class="d-flex min-vh-100 bg-light text-dark">
-<?php include __DIR__.'/navbar.php'; ?>
-<?php include __DIR__.'/sidebar.php'; ?>
+<?php $this->load->view('navbar'); ?>
+<?php $this->load->view('sidebar'); ?>
 <div class="content">
 <div class="container mt-5">
       <div class="d-flex justify-content-between align-items-center mb-4">

--- a/application/views/lista_clientes.php
+++ b/application/views/lista_clientes.php
@@ -7,8 +7,8 @@
   <link href="../../style.css" rel="stylesheet">
 </head>
 <body class="d-flex min-vh-100 bg-light text-dark">
-<?php include __DIR__.'/navbar.php'; ?>
-<?php include __DIR__.'/sidebar.php'; ?>
+<?php $this->load->view('navbar'); ?>
+<?php $this->load->view('sidebar'); ?>
 <div class="container mt-5">
   <h3>Lista de Clientes</h3>
   <table class="table table-striped table-hover align-middle">

--- a/application/views/lista_produtos.php
+++ b/application/views/lista_produtos.php
@@ -11,8 +11,8 @@
   <link href="../../style.css" rel="stylesheet">
 </head>
 <body class="d-flex min-vh-100 bg-light text-dark">
-<?php include __DIR__.'/navbar.php'; ?>
-<?php include __DIR__.'/sidebar.php'; ?>
+<?php $this->load->view('navbar'); ?>
+<?php $this->load->view('sidebar'); ?>
 <div class="content">
 <div class="container-fluid">
       <h4 class="mb-4">Lista de Produtos</h4>

--- a/application/views/nova_venda.php
+++ b/application/views/nova_venda.php
@@ -12,8 +12,8 @@
   </style>
 </head>
 <body class="d-flex min-vh-100 bg-light text-dark">
-<?php include __DIR__.'/navbar.php'; ?>
-<?php include __DIR__.'/sidebar.php'; ?>
+<?php $this->load->view('navbar'); ?>
+<?php $this->load->view('sidebar'); ?>
 <div class="content">
 <div class="container-fluid">
       <h4 class="mb-4">Registrar Nova Venda</h4>

--- a/application/views/relatorios_caixa.php
+++ b/application/views/relatorios_caixa.php
@@ -11,8 +11,8 @@
   <link href="../../style.css" rel="stylesheet">
 </head>
 <body class="d-flex min-vh-100 bg-light text-dark">
-<?php include __DIR__.'/navbar.php'; ?>
-<?php include __DIR__.'/sidebar.php'; ?>
+<?php $this->load->view('navbar'); ?>
+<?php $this->load->view('sidebar'); ?>
 <div class="content">
 <div class="container mt-5">
       <div class="d-flex justify-content-between align-items-center mb-4">

--- a/application/views/relatorios_estoque.php
+++ b/application/views/relatorios_estoque.php
@@ -11,8 +11,8 @@
   <link href="../../style.css" rel="stylesheet">
 </head>
 <body class="d-flex min-vh-100 bg-light text-dark">
-<?php include __DIR__.'/navbar.php'; ?>
-<?php include __DIR__.'/sidebar.php'; ?>
+<?php $this->load->view('navbar'); ?>
+<?php $this->load->view('sidebar'); ?>
 <div class="content">
 <div class="container mt-5">
       <div class="d-flex justify-content-between align-items-center mb-4">

--- a/application/views/relatorios_fiscais.php
+++ b/application/views/relatorios_fiscais.php
@@ -11,8 +11,8 @@
   <link href="../../style.css" rel="stylesheet">
 </head>
 <body class="d-flex min-vh-100 bg-light text-dark">
-<?php include __DIR__.'/navbar.php'; ?>
-<?php include __DIR__.'/sidebar.php'; ?>
+<?php $this->load->view('navbar'); ?>
+<?php $this->load->view('sidebar'); ?>
 <div class="content">
 <div class="container mt-5">
       <div class="d-flex justify-content-between align-items-center mb-4">

--- a/application/views/relatorios_vendas.php
+++ b/application/views/relatorios_vendas.php
@@ -11,8 +11,8 @@
   <link href="../../style.css" rel="stylesheet">
 </head>
 <body class="d-flex min-vh-100 bg-light text-dark">
-<?php include __DIR__.'/navbar.php'; ?>
-<?php include __DIR__.'/sidebar.php'; ?>
+<?php $this->load->view('navbar'); ?>
+<?php $this->load->view('sidebar'); ?>
 <div class="content">
 <div class="container mt-5">
       <div class="d-flex justify-content-between align-items-center mb-4">


### PR DESCRIPTION
## Summary
- Convert `Cliente_model` to extend `CI_Model` and use query builder
- Replace PHP includes with `$this->load->view()` calls in views

## Testing
- `php -l application/models/Cliente_model.php`
- `php -l application/views/adicionar_produto.php`
- `php -l application/views/cadastrar.php`
- `php -l application/views/editar.php`
- `php -l application/views/editar_produto.php`
- `php -l application/views/fluxo_caixa.php`
- `php -l application/views/lista_clientes.php`
- `php -l application/views/lista_produtos.php`
- `php -l application/views/nova_venda.php`
- `php -l application/views/relatorios_caixa.php`
- `php -l application/views/relatorios_estoque.php`
- `php -l application/views/relatorios_fiscais.php`
- `php -l application/views/relatorios_vendas.php`

------
https://chatgpt.com/codex/tasks/task_e_689f09d79a28832db48c316dd66b0aaa