### PR TITLE
Fix client save fields to match database

### DIFF
--- a/application/controllers/Clientes.php
+++ b/application/controllers/Clientes.php
@@ -20,9 +20,8 @@ class Clientes extends CI_Controller {
     {
         $this->load->model('Cliente_model');
         $dados = [
-            'nome' => $this->input->post('nome'),
-            'endereco' => $this->input->post('endereco'),
-            'telefone' => $this->input->post('telefone'),
+            'nome'  => $this->input->post('nome'),
+            'email' => $this->input->post('email'),
         ];
 
         $success = $this->Cliente_model->insert($dados);

--- a/application/views/cadastrar.php
+++ b/application/views/cadastrar.php
@@ -32,15 +32,10 @@
               <label for="nome" class="form-label">Nome completo</label>
               <input type="text" class="form-control" id="nome" name="nome" placeholder="Ex: João da Silva" required autocomplete="off">
             </div>
-            <!-- Campo para o endereço do cliente -->
+            <!-- Campo para o email do cliente -->
             <div class="mb-3">
-              <label for="endereco" class="form-label">Endereço</label>
-              <input type="text" class="form-control" id="endereco" name="endereco" placeholder="Rua, Bairro, Cidade" required autocomplete="off">
-            </div>
-            <!-- Campo para o telefone do cliente -->
-            <div class="mb-3">
-              <label for="telefone" class="form-label">Telefone</label>
-              <input type="tel" class="form-control" id="telefone" name="telefone" placeholder="Ex: 923 000 000" required autocomplete="off">
+              <label for="email" class="form-label">Email</label>
+              <input type="email" class="form-control" id="email" name="email" placeholder="Ex: joao@email.com" required autocomplete="off">
             </div>
             <button type="submit" class="btn btn-primary"><i class="bi bi-save"></i> Salvar Cliente</button>
           </form>

--- a/application/views/editar.php
+++ b/application/views/editar.php
@@ -22,12 +22,8 @@
               <input type="text" class="form-control" id="nome" value="" required autocomplete="off">
             </div>
             <div class="mb-3">
-              <label for="endereco" class="form-label">Endereço</label>
-              <input type="text" class="form-control" id="endereco" name="endereco" value="" required autocomplete="off">
-            </div>
-            <div class="mb-3">
-              <label for="telefone" class="form-label">Telefone</label>
-              <input type="tel" class="form-control" id="telefone" value="" required autocomplete="off">
+              <label for="email" class="form-label">Email</label>
+              <input type="email" class="form-control" id="email" name="email" value="" required autocomplete="off">
             </div>
             <button type="submit" class="btn btn-primary"><i class="bi bi-save"></i> Atualizar Cliente</button>
           </form>


### PR DESCRIPTION
## Summary
- Replace address and phone fields with email in client creation and edit views
- Store client name and email in controller when saving

## Testing
- `php -l application/controllers/Clientes.php`
- `php -l application/views/cadastrar.php`
- `php -l application/views/editar.php`


------
https://chatgpt.com/codex/tasks/task_e_68a46fcbf2a88322b77be232a0a10e19