### PR TITLE
Enable client deletion from list

### DIFF
--- a/application/controllers/Clientes.php
+++ b/application/controllers/Clientes.php
@@ -33,6 +33,17 @@ class Clientes extends CI_Controller {
             ->set_output(json_encode(['status' => $success ? 'success' : 'error']));
     }
 
+    public function apagar($id)
+    {
+        $this->load->model('Cliente_model');
+        $success = $this->Cliente_model->delete($id);
+
+        $this->output
+            ->set_content_type('application/json')
+            ->set_status_header($success ? 200 : 500)
+            ->set_output(json_encode(['status' => $success ? 'success' : 'error']));
+    }
+
     public function editar()
     {
         $this->load->view('editar');

--- a/application/models/Cliente_model.php
+++ b/application/models/Cliente_model.php
@@ -20,4 +20,8 @@ class Cliente_model extends CI_Model {
     public function insert($data) {
         return $this->db->insert($this->table, $data);
     }
+
+    public function delete($id) {
+        return $this->db->delete($this->table, ['id' => $id]);
+    }
 }

--- a/application/views/lista_clientes.php
+++ b/application/views/lista_clientes.php
@@ -37,9 +37,9 @@
                 <td><?= $c['telefone']; ?></td>
                 <td><?= $c['endereco']; ?></td>
                 <td>
-                  <button class="btn btn-sm btn-primary me-1" onclick="window.location.href='<?= site_url('clientes/editar'); ?>'"><i class="bi bi-pencil"></i></button>
-                  <button class="btn btn-sm btn-danger me-1" data-bs-toggle="modal" data-bs-target="#confirmDeleteModal"><i class="bi bi-trash"></i></button>
-                  <button class="btn btn-sm btn-secondary" data-bs-toggle="modal" data-bs-target="#historyModal"><i class="bi bi-clock-history"></i></button>
+                    <button class="btn btn-sm btn-primary me-1" onclick="window.location.href='<?= site_url('clientes/editar'); ?>'"><i class="bi bi-pencil"></i></button>
+                    <button class="btn btn-sm btn-danger me-1" data-bs-toggle="modal" data-bs-target="#confirmDeleteModal" data-id="<?= $c['id']; ?>"><i class="bi bi-trash"></i></button>
+                    <button class="btn btn-sm btn-secondary" data-bs-toggle="modal" data-bs-target="#historyModal"><i class="bi bi-clock-history"></i></button>
                 </td>
               </tr>
             <?php endforeach; ?>
@@ -64,7 +64,7 @@
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-          <button type="button" class="btn btn-danger">Apagar</button>
+            <button type="button" class="btn btn-danger" id="confirmDeleteBtn">Apagar</button>
         </div>
       </div>
     </div>
@@ -114,6 +114,25 @@
           }
         });
       }
+
+      let clienteId;
+      $('#confirmDeleteModal').on('show.bs.modal', function (event) {
+        const button = $(event.relatedTarget);
+        clienteId = button.data('id');
+      });
+
+      $('#confirmDeleteBtn').on('click', function () {
+        $.ajax({
+          url: '<?= site_url('clientes/apagar'); ?>/' + clienteId,
+          type: 'POST',
+          success: function () {
+            location.reload();
+          },
+          error: function () {
+            alert('Erro ao apagar cliente');
+          }
+        });
+      });
     });
   </script>
   <script src="<?= base_url('assets/layout.js'); ?>"></script>


### PR DESCRIPTION
## Summary
- Add delete method in `Cliente_model` and corresponding `apagar` action in `Clientes` controller
- Wire client list delete button with confirmation modal and AJAX call

## Testing
- `php -l application/models/Cliente_model.php`
- `php -l application/controllers/Clientes.php`
- `php -l application/views/lista_clientes.php`

------
https://chatgpt.com/codex/tasks/task_e_68a57a7fcd9083229190c24d9851cf1e