### PR TITLE
Habilita edição de clientes na Lista de Clientes

### DIFF
--- a/application/controllers/Clientes.php
+++ b/application/controllers/Clientes.php
@@ -44,8 +44,27 @@ class Clientes extends CI_Controller {
             ->set_output(json_encode(['status' => $success ? 'success' : 'error']));
     }
 
-    public function editar()
+    public function editar($id)
     {
-        $this->load->view('editar');
+        $this->load->model('Cliente_model');
+        $cliente = $this->Cliente_model->get($id);
+        $this->load->view('editar', ['dataVar' => ['cliente' => $cliente]]);
+    }
+
+    public function atualizar($id)
+    {
+        $this->load->model('Cliente_model');
+        $dados = [
+            'nome'     => $this->input->post('nome'),
+            'telefone' => $this->input->post('telefone'),
+            'endereco' => $this->input->post('endereco'),
+        ];
+
+        $success = $this->Cliente_model->update($id, $dados);
+
+        $this->output
+            ->set_content_type('application/json')
+            ->set_status_header($success ? 200 : 500)
+            ->set_output(json_encode(['status' => $success ? 'success' : 'error']));
     }
 }

--- a/application/models/Cliente_model.php
+++ b/application/models/Cliente_model.php
@@ -17,8 +17,16 @@ class Cliente_model extends CI_Model {
         return $this->get_all();
     }
 
+    public function get($id) {
+        return $this->db->get_where($this->table, ['id' => $id])->row_array();
+    }
+
     public function insert($data) {
         return $this->db->insert($this->table, $data);
+    }
+
+    public function update($id, $data) {
+        return $this->db->update($this->table, $data, ['id' => $id]);
     }
 
     public function delete($id) {

--- a/application/views/editar.php
+++ b/application/views/editar.php
@@ -7,6 +7,9 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
   <link href="<?= base_url('assets/style.css'); ?>" rel="stylesheet">
+  <style>
+    .toast { position: fixed; top: 20px; right: 20px; z-index: 9999; }
+  </style>
 </head>
 <body class="d-flex min-vh-100 bg-light text-dark">
 <?php $this->load->view('navbar'); ?>
@@ -16,19 +19,19 @@
       <h4 class="mb-4">Editar Cliente</h4>
       <div class="card shadow-sm">
         <div class="card-body">
-          <form>
+          <form id="clienteForm">
             <div class="mb-3">
               <label for="nome" class="form-label">Nome completo</label>
-              <input type="text" class="form-control" id="nome" value="" required autocomplete="off">
+              <input type="text" class="form-control" id="nome" name="nome" value="<?= $dataVar['cliente']['nome']; ?>" required autocomplete="off">
             </div>
-              <div class="mb-3">
-                <label for="telefone" class="form-label">Número de Telefone</label>
-                <input type="text" class="form-control" id="telefone" name="telefone" value="" required autocomplete="off">
-              </div>
-              <div class="mb-3">
-                <label for="endereco" class="form-label">Endereço</label>
-                <input type="text" class="form-control" id="endereco" name="endereco" value="" required autocomplete="off">
-              </div>
+            <div class="mb-3">
+              <label for="telefone" class="form-label">Número de Telefone</label>
+              <input type="text" class="form-control" id="telefone" name="telefone" value="<?= $dataVar['cliente']['telefone']; ?>" required autocomplete="off">
+            </div>
+            <div class="mb-3">
+              <label for="endereco" class="form-label">Endereço</label>
+              <input type="text" class="form-control" id="endereco" name="endereco" value="<?= $dataVar['cliente']['endereco']; ?>" required autocomplete="off">
+            </div>
             <button type="submit" class="btn btn-primary"><i class="bi bi-save"></i> Atualizar Cliente</button>
           </form>
         </div>
@@ -36,9 +39,59 @@
     </div>
   </div>
 
+  <!-- Toasts -->
+  <div id="toast-success" class="toast align-items-center text-bg-success border-0" role="alert" aria-live="assertive" aria-atomic="true" style="display:none;">
+    <div class="d-flex">
+      <div class="toast-body">
+        Cliente atualizado com sucesso!
+      </div>
+      <button type="button" class="btn-close btn-close-white me-2 m-auto" onclick="hideToast('toast-success')"></button>
+    </div>
+  </div>
+  <div id="toast-error" class="toast align-items-center text-bg-danger border-0" role="alert" aria-live="assertive" aria-atomic="true" style="display:none;">
+    <div class="d-flex">
+      <div class="toast-body">
+        Ocorreu um erro ao atualizar o cliente.
+      </div>
+      <button type="button" class="btn-close btn-close-white me-2 m-auto" onclick="hideToast('toast-error')"></button>
+    </div>
+  </div>
+
   <!-- Scripts -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script src="<?= base_url('assets/layout.js'); ?>"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      const form = document.getElementById('clienteForm');
+      form.addEventListener('submit', function(event) {
+        event.preventDefault();
+        const formData = new FormData(form);
+        fetch('<?= site_url('clientes/atualizar/' . $dataVar['cliente']['id']); ?>', {
+          method: 'POST',
+          body: formData
+        })
+        .then(response => {
+          if (!response.ok) throw new Error();
+          return response.json();
+        })
+        .then(() => {
+          showToast('toast-success');
+        })
+        .catch(() => {
+          showToast('toast-error');
+        });
+      });
+    });
+
+    function showToast(id) {
+      const toast = document.getElementById(id);
+      toast.style.display = 'block';
+      setTimeout(() => { toast.style.display = 'none'; }, 3000);
+    }
+    function hideToast(id) {
+      document.getElementById(id).style.display = 'none';
+    }
+  </script>
 </body>
 </html>
 

--- a/application/views/lista_clientes.php
+++ b/application/views/lista_clientes.php
@@ -37,7 +37,7 @@
                 <td><?= $c['telefone']; ?></td>
                 <td><?= $c['endereco']; ?></td>
                 <td>
-                    <button class="btn btn-sm btn-primary me-1" onclick="window.location.href='<?= site_url('clientes/editar'); ?>'"><i class="bi bi-pencil"></i></button>
+                    <button class="btn btn-sm btn-primary me-1" onclick="window.location.href='<?= site_url('clientes/editar/'.$c['id']); ?>'"><i class="bi bi-pencil"></i></button>
                     <button class="btn btn-sm btn-danger me-1" data-bs-toggle="modal" data-bs-target="#confirmDeleteModal" data-id="<?= $c['id']; ?>"><i class="bi bi-trash"></i></button>
                     <button class="btn btn-sm btn-secondary" data-bs-toggle="modal" data-bs-target="#historyModal"><i class="bi bi-clock-history"></i></button>
                 </td>


### PR DESCRIPTION
## Sumário
- permite abrir a edição diretamente pela tabela
- adiciona rotas para carregar e atualizar clientes
- preenche formulário de edição e exibe toasts de feedback

## Testes
- `php -l application/controllers/Clientes.php`
- `php -l application/models/Cliente_model.php`
- `php -l application/views/editar.php`
- `php -l application/views/lista_clientes.php`
- `vendor/bin/phpunit` *(falhou: No such file or directory)*
- `composer test:coverage` *(falhou: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a57eee5b688322810813162f2d2a13