### PR TITLE
feat: add image and description columns to product list

### DIFF
--- a/application/views/lista_produtos.php
+++ b/application/views/lista_produtos.php
@@ -23,20 +23,26 @@
             <thead class="table-light">
               <tr>
                 <th>#</th>
+                <th>Imagem</th>
                 <th>Produto</th>
                 <th>Categoria</th>
                 <th>Preço</th>
                 <th>Estoque</th>
+                <th>Descrição</th>
                 <th>Ações</th>
               </tr>
             </thead>
             <tbody>
               <tr>
                 <td>1</td>
+                <td><img src="https://via.placeholder.com/50" alt="Óleo de Motor 5W30" class="img-thumbnail"></td>
                 <td>Óleo de Motor 5W30</td>
                 <td>Lubrificantes</td>
                 <td>Kz 8.000</td>
                 <td>20</td>
+                <td>
+                  <button class="btn btn-sm btn-info" data-bs-toggle="modal" data-bs-target="#infoModal" data-nome="Óleo de Motor 5W30" data-descricao="Óleo de motor sintético 5W30 de alta performance.">Ver</button>
+                </td>
                 <td>
                   <button class="btn btn-sm btn-primary me-1" onclick="window.location.href='<?= site_url('produtos/editar'); ?>'"><i class="bi bi-pencil"></i></button>
                   <button class="btn btn-sm btn-danger me-1" data-bs-toggle="modal" data-bs-target="#confirmDeleteModal"><i class="bi bi-trash"></i></button>
@@ -45,10 +51,14 @@
               </tr>
               <tr>
                 <td>2</td>
+                <td><img src="https://via.placeholder.com/50" alt="Filtro de Ar" class="img-thumbnail"></td>
                 <td>Filtro de Ar</td>
                 <td>Filtros</td>
                 <td>Kz 2.500</td>
                 <td>35</td>
+                <td>
+                  <button class="btn btn-sm btn-info" data-bs-toggle="modal" data-bs-target="#infoModal" data-nome="Filtro de Ar" data-descricao="Filtro de ar de alta eficiência para motores.">Ver</button>
+                </td>
                 <td>
                   <button class="btn btn-sm btn-primary me-1" onclick="window.location.href='<?= site_url('produtos/editar'); ?>'"><i class="bi bi-pencil"></i></button>
                   <button class="btn btn-sm btn-danger me-1" data-bs-toggle="modal" data-bs-target="#confirmDeleteModal"><i class="bi bi-trash"></i></button>
@@ -57,10 +67,14 @@
               </tr>
               <tr>
                 <td>3</td>
+                <td><img src="https://via.placeholder.com/50" alt="Pastilha de Freio" class="img-thumbnail"></td>
                 <td>Pastilha de Freio</td>
                 <td>Freios</td>
                 <td>Kz 12.000</td>
                 <td>15</td>
+                <td>
+                  <button class="btn btn-sm btn-info" data-bs-toggle="modal" data-bs-target="#infoModal" data-nome="Pastilha de Freio" data-descricao="Pastilhas de freio resistentes ao desgaste.">Ver</button>
+                </td>
                 <td>
                   <button class="btn btn-sm btn-primary me-1" onclick="window.location.href='<?= site_url('produtos/editar'); ?>'"><i class="bi bi-pencil"></i></button>
                   <button class="btn btn-sm btn-danger me-1" data-bs-toggle="modal" data-bs-target="#confirmDeleteModal"><i class="bi bi-trash"></i></button>
@@ -116,6 +130,22 @@
     </div>
   </div>
 
+  <!-- Modal de informações do produto -->
+  <div class="modal fade" id="infoModal" tabindex="-1" aria-labelledby="infoLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="infoLabel"></h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body" id="infoDescricao"></div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fechar</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- Scripts -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script src="https://code.jquery.com/jquery-3.7.0.min.js"></script>
@@ -139,6 +169,15 @@
           }
         });
       }
+
+      const infoModal = document.getElementById('infoModal');
+      infoModal.addEventListener('show.bs.modal', function (event) {
+        const button = event.relatedTarget;
+        const nome = button.getAttribute('data-nome');
+        const descricao = button.getAttribute('data-descricao');
+        document.getElementById('infoLabel').textContent = nome;
+        document.getElementById('infoDescricao').textContent = descricao;
+      });
     });
   </script>
   <script src="<?= base_url('assets/layout.js'); ?>"></script>


### PR DESCRIPTION
## Summary
- add image column to product list
- add description column with modal to display product information
- include JavaScript handler for dynamic product info modal

## Testing
- `php -l application/views/lista_produtos.php`
- `composer run test:coverage` *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a58ce63e408322b210e084f64f77f1