### PR TITLE
Move product description action button to actions column

### DIFF
--- a/application/views/lista_produtos.php
+++ b/application/views/lista_produtos.php
@@ -40,10 +40,9 @@
                 <td>Lubrificantes</td>
                 <td>Kz 8.000</td>
                 <td>20</td>
+                <td class="text-truncate" style="max-width: 200px;">Óleo de motor sintético 5W30 de alta performance.</td>
                 <td>
-                  <button class="btn btn-sm btn-info" data-bs-toggle="modal" data-bs-target="#infoModal" data-nome="Óleo de Motor 5W30" data-descricao="Óleo de motor sintético 5W30 de alta performance.">Ver</button>
-                </td>
-                <td>
+                  <button class="btn btn-sm btn-info me-1" data-bs-toggle="modal" data-bs-target="#infoModal" data-nome="Óleo de Motor 5W30" data-descricao="Óleo de motor sintético 5W30 de alta performance.">Ver</button>
                   <button class="btn btn-sm btn-primary me-1" onclick="window.location.href='<?= site_url('produtos/editar'); ?>'"><i class="bi bi-pencil"></i></button>
                   <button class="btn btn-sm btn-danger me-1" data-bs-toggle="modal" data-bs-target="#confirmDeleteModal"><i class="bi bi-trash"></i></button>
                   <button class="btn btn-sm btn-secondary" data-bs-toggle="modal" data-bs-target="#historyModal"><i class="bi bi-clock-history"></i></button>
@@ -56,10 +55,9 @@
                 <td>Filtros</td>
                 <td>Kz 2.500</td>
                 <td>35</td>
+                <td class="text-truncate" style="max-width: 200px;">Filtro de ar de alta eficiência para motores.</td>
                 <td>
-                  <button class="btn btn-sm btn-info" data-bs-toggle="modal" data-bs-target="#infoModal" data-nome="Filtro de Ar" data-descricao="Filtro de ar de alta eficiência para motores.">Ver</button>
-                </td>
-                <td>
+                  <button class="btn btn-sm btn-info me-1" data-bs-toggle="modal" data-bs-target="#infoModal" data-nome="Filtro de Ar" data-descricao="Filtro de ar de alta eficiência para motores.">Ver</button>
                   <button class="btn btn-sm btn-primary me-1" onclick="window.location.href='<?= site_url('produtos/editar'); ?>'"><i class="bi bi-pencil"></i></button>
                   <button class="btn btn-sm btn-danger me-1" data-bs-toggle="modal" data-bs-target="#confirmDeleteModal"><i class="bi bi-trash"></i></button>
                   <button class="btn btn-sm btn-secondary" data-bs-toggle="modal" data-bs-target="#historyModal"><i class="bi bi-clock-history"></i></button>
@@ -72,10 +70,9 @@
                 <td>Freios</td>
                 <td>Kz 12.000</td>
                 <td>15</td>
+                <td class="text-truncate" style="max-width: 200px;">Pastilhas de freio resistentes ao desgaste.</td>
                 <td>
-                  <button class="btn btn-sm btn-info" data-bs-toggle="modal" data-bs-target="#infoModal" data-nome="Pastilha de Freio" data-descricao="Pastilhas de freio resistentes ao desgaste.">Ver</button>
-                </td>
-                <td>
+                  <button class="btn btn-sm btn-info me-1" data-bs-toggle="modal" data-bs-target="#infoModal" data-nome="Pastilha de Freio" data-descricao="Pastilhas de freio resistentes ao desgaste.">Ver</button>
                   <button class="btn btn-sm btn-primary me-1" onclick="window.location.href='<?= site_url('produtos/editar'); ?>'"><i class="bi bi-pencil"></i></button>
                   <button class="btn btn-sm btn-danger me-1" data-bs-toggle="modal" data-bs-target="#confirmDeleteModal"><i class="bi bi-trash"></i></button>
                   <button class="btn btn-sm btn-secondary" data-bs-toggle="modal" data-bs-target="#historyModal"><i class="bi bi-clock-history"></i></button>


### PR DESCRIPTION
## Summary
- Show product descriptions directly in table rows
- Move "Ver" modal trigger into the actions column

## Testing
- `php -l application/views/lista_produtos.php`


------
https://chatgpt.com/codex/tasks/task_e_68a58e700ac08322a98ee4e98f041812