### PR TITLE
feat: persist products and display in list

### DIFF
--- a/application/controllers/Produtos.php
+++ b/application/controllers/Produtos.php
@@ -2,9 +2,16 @@
 defined('BASEPATH') OR exit('No direct script access allowed');
 
 class Produtos extends CI_Controller {
+    public function __construct()
+    {
+        parent::__construct();
+        $this->load->model('Produto_model');
+    }
+
     public function lista()
     {
-        $this->load->view('lista_produtos');
+        $data['produtos'] = $this->Produto_model->todos();
+        $this->load->view('lista_produtos', $data);
     }
 
     public function adicionar()
@@ -12,7 +19,36 @@ class Produtos extends CI_Controller {
         $this->load->view('adicionar_produto');
     }
 
-    public function editar()
+    public function salvar()
+    {
+        $config['upload_path']   = './uploads/';
+        $config['allowed_types'] = 'gif|jpg|jpeg|png';
+        $config['max_size']      = 2048;
+        $this->load->library('upload', $config);
+
+        if (!$this->upload->do_upload('imagem')) {
+            echo json_encode(['status' => 'error', 'message' => $this->upload->display_errors()]);
+            return;
+        }
+
+        $file_data = $this->upload->data();
+        $produto = [
+            'nome'      => $this->input->post('nome'),
+            'categoria' => $this->input->post('categoria'),
+            'preco'     => $this->input->post('preco'),
+            'estoque'   => $this->input->post('estoque'),
+            'descricao' => $this->input->post('descricao'),
+            'imagem'    => $file_data['file_name']
+        ];
+
+        if ($this->Produto_model->inserir($produto)) {
+            echo json_encode(['status' => 'success']);
+        } else {
+            echo json_encode(['status' => 'error']);
+        }
+    }
+
+    public function editar($id = NULL)
     {
         $this->load->view('editar_produto');
     }

--- a/application/models/Produto_model.php
+++ b/application/models/Produto_model.php
@@ -1,0 +1,17 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Produto_model extends CI_Model {
+    public function __construct() {
+        parent::__construct();
+        $this->load->database();
+    }
+
+    public function inserir($data) {
+        return $this->db->insert('produtos', $data);
+    }
+
+    public function todos() {
+        return $this->db->get('produtos')->result();
+    }
+}

--- a/application/views/adicionar_produto.php
+++ b/application/views/adicionar_produto.php
@@ -19,18 +19,18 @@
       <h4 class="mb-4">Adicionar Novo Produto</h4>
       <div class="card shadow-sm">
         <div class="card-body">
-          <form id="produtoForm">
+          <form id="produtoForm" enctype="multipart/form-data">
             <div class="mb-3">
               <label for="imagem" class="form-label">Imagem do Produto</label>
-              <input type="file" class="form-control" id="imagem" accept="image/*" required>
+              <input type="file" class="form-control" id="imagem" name="imagem" accept="image/*" required>
             </div>
             <div class="mb-3">
               <label for="nome" class="form-label">Nome do Produto</label>
-              <input type="text" class="form-control" id="nome" placeholder="Ex: Óleo de Motor" required autocomplete="off">
+              <input type="text" class="form-control" id="nome" name="nome" placeholder="Ex: Óleo de Motor" required autocomplete="off">
             </div>
             <div class="mb-3">
               <label for="categoria" class="form-label">Categoria</label>
-              <select class="form-select" id="categoria" required>
+              <select class="form-select" id="categoria" name="categoria" required>
                 <option value="" selected disabled>Selecione uma categoria</option>
                 <option value="Lubrificantes">Lubrificantes</option>
                 <option value="Filtros">Filtros</option>
@@ -40,15 +40,15 @@
             </div>
             <div class="mb-3">
               <label for="preco" class="form-label">Preço</label>
-              <input type="number" class="form-control" id="preco" placeholder="Ex: 8000" required autocomplete="off">
+              <input type="number" class="form-control" id="preco" name="preco" placeholder="Ex: 8000" required autocomplete="off">
             </div>
             <div class="mb-3">
               <label for="estoque" class="form-label">Estoque</label>
-              <input type="number" class="form-control" id="estoque" placeholder="Ex: 20" required autocomplete="off">
+              <input type="number" class="form-control" id="estoque" name="estoque" placeholder="Ex: 20" required autocomplete="off">
             </div>
             <div class="mb-3">
               <label for="descricao" class="form-label">Descrição</label>
-              <textarea class="form-control" id="descricao" rows="3" placeholder="Detalhes do produto"></textarea>
+              <textarea class="form-control" id="descricao" name="descricao" rows="3" placeholder="Detalhes do produto"></textarea>
             </div>
             <button type="submit" class="btn btn-primary"><i class="bi bi-save"></i> Salvar Produto</button>
           </form>
@@ -83,8 +83,21 @@
       const form = document.getElementById('produtoForm');
       form.onsubmit = function(event) {
         event.preventDefault();
-        showToast('toast-success');
-        form.reset();
+        const formData = new FormData(form);
+        fetch('<?= site_url('produtos/salvar'); ?>', {
+          method: 'POST',
+          body: formData
+        })
+        .then(response => response.json())
+        .then(data => {
+          if (data.status === 'success') {
+            showToast('toast-success');
+            form.reset();
+          } else {
+            showToast('toast-error');
+          }
+        })
+        .catch(() => showToast('toast-error'));
       };
     });
 

--- a/application/views/lista_produtos.php
+++ b/application/views/lista_produtos.php
@@ -32,48 +32,28 @@
               </tr>
             </thead>
             <tbody>
-              <tr>
-                <td>1</td>
-                <td><img src="https://via.placeholder.com/50" alt="Óleo de Motor 5W30" class="img-thumbnail"></td>
-                <td>Óleo de Motor 5W30</td>
-                <td>Lubrificantes</td>
-                <td>Kz 8.000</td>
-                <td>20</td>
-                <td>
-                  <button class="btn btn-sm btn-info me-1" data-bs-toggle="modal" data-bs-target="#infoModal" data-nome="Óleo de Motor 5W30" data-descricao="Óleo de motor sintético 5W30 de alta performance."><i class="bi bi-info-circle"></i></button>
-                  <button class="btn btn-sm btn-primary me-1" onclick="window.location.href='<?= site_url('produtos/editar'); ?>'"><i class="bi bi-pencil"></i></button>
-                  <button class="btn btn-sm btn-danger me-1" data-bs-toggle="modal" data-bs-target="#confirmDeleteModal"><i class="bi bi-trash"></i></button>
-                  <button class="btn btn-sm btn-secondary" data-bs-toggle="modal" data-bs-target="#historyModal"><i class="bi bi-clock-history"></i></button>
-                </td>
-              </tr>
-              <tr>
-                <td>2</td>
-                <td><img src="https://via.placeholder.com/50" alt="Filtro de Ar" class="img-thumbnail"></td>
-                <td>Filtro de Ar</td>
-                <td>Filtros</td>
-                <td>Kz 2.500</td>
-                <td>35</td>
-                <td>
-                  <button class="btn btn-sm btn-info me-1" data-bs-toggle="modal" data-bs-target="#infoModal" data-nome="Filtro de Ar" data-descricao="Filtro de ar de alta eficiência para motores."><i class="bi bi-info-circle"></i></button>
-                  <button class="btn btn-sm btn-primary me-1" onclick="window.location.href='<?= site_url('produtos/editar'); ?>'"><i class="bi bi-pencil"></i></button>
-                  <button class="btn btn-sm btn-danger me-1" data-bs-toggle="modal" data-bs-target="#confirmDeleteModal"><i class="bi bi-trash"></i></button>
-                  <button class="btn btn-sm btn-secondary" data-bs-toggle="modal" data-bs-target="#historyModal"><i class="bi bi-clock-history"></i></button>
-                </td>
-              </tr>
-              <tr>
-                <td>3</td>
-                <td><img src="https://via.placeholder.com/50" alt="Pastilha de Freio" class="img-thumbnail"></td>
-                <td>Pastilha de Freio</td>
-                <td>Freios</td>
-                <td>Kz 12.000</td>
-                <td>15</td>
-                <td>
-                  <button class="btn btn-sm btn-info me-1" data-bs-toggle="modal" data-bs-target="#infoModal" data-nome="Pastilha de Freio" data-descricao="Pastilhas de freio resistentes ao desgaste."><i class="bi bi-info-circle"></i></button>
-                  <button class="btn btn-sm btn-primary me-1" onclick="window.location.href='<?= site_url('produtos/editar'); ?>'"><i class="bi bi-pencil"></i></button>
-                  <button class="btn btn-sm btn-danger me-1" data-bs-toggle="modal" data-bs-target="#confirmDeleteModal"><i class="bi bi-trash"></i></button>
-                  <button class="btn btn-sm btn-secondary" data-bs-toggle="modal" data-bs-target="#historyModal"><i class="bi bi-clock-history"></i></button>
-                </td>
-              </tr>
+              <?php if (!empty($produtos)): ?>
+                <?php foreach ($produtos as $produto): ?>
+                  <tr>
+                    <td><?= $produto->id; ?></td>
+                    <td><img src="<?= base_url('uploads/' . $produto->imagem); ?>" alt="<?= $produto->nome; ?>" class="img-thumbnail" style="width:50px;"></td>
+                    <td><?= $produto->nome; ?></td>
+                    <td><?= $produto->categoria; ?></td>
+                    <td>Kz <?= number_format($produto->preco, 2, ',', '.'); ?></td>
+                    <td><?= $produto->estoque; ?></td>
+                    <td>
+                      <button class="btn btn-sm btn-info me-1" data-bs-toggle="modal" data-bs-target="#infoModal" data-nome="<?= $produto->nome; ?>" data-descricao="<?= $produto->descricao; ?>"><i class="bi bi-info-circle"></i></button>
+                      <button class="btn btn-sm btn-primary me-1" onclick="window.location.href='<?= site_url('produtos/editar/' . $produto->id); ?>'"><i class="bi bi-pencil"></i></button>
+                      <button class="btn btn-sm btn-danger me-1" data-bs-toggle="modal" data-bs-target="#confirmDeleteModal" data-id="<?= $produto->id; ?>"><i class="bi bi-trash"></i></button>
+                      <button class="btn btn-sm btn-secondary" data-bs-toggle="modal" data-bs-target="#historyModal"><i class="bi bi-clock-history"></i></button>
+                    </td>
+                  </tr>
+                <?php endforeach; ?>
+              <?php else: ?>
+                <tr>
+                  <td colspan="7" class="text-center">Nenhum produto cadastrado.</td>
+                </tr>
+              <?php endif; ?>
             </tbody>
           </table>
           </div>

--- a/database/produtos.sql
+++ b/database/produtos.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `produtos` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `nome` varchar(255) NOT NULL,
+  `categoria` varchar(100) NOT NULL,
+  `preco` decimal(10,2) NOT NULL,
+  `estoque` int(11) NOT NULL,
+  `descricao` text,
+  `imagem` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
## Summary
- add Produto_model for database interactions
- persist new products via Produtos::salvar and show toast feedback
- render product list from database and include SQL schema

## Testing
- `php -l application/models/Produto_model.php`
- `php -l application/controllers/Produtos.php`
- `php -l application/views/adicionar_produto.php`
- `php -l application/views/lista_produtos.php`
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68a59e5bebac8322b8f2a670514dea61