### PR TITLE
Show success pop-up and redirect after product creation

### DIFF
--- a/application/views/adicionar_produto.php
+++ b/application/views/adicionar_produto.php
@@ -91,7 +91,9 @@
         .then(response => response.json())
         .then(data => {
           if (data.status === 'success') {
-            showToast('toast-success');
+            showToast('toast-success', () => {
+              window.location.href = '<?= site_url('produtos/lista'); ?>';
+            });
             form.reset();
           } else {
             showToast('toast-error');
@@ -101,10 +103,13 @@
       };
     });
 
-    function showToast(id) {
+    function showToast(id, callback) {
       const toast = document.getElementById(id);
       toast.style.display = 'block';
-      setTimeout(() => { toast.style.display = 'none'; }, 3000);
+      setTimeout(() => {
+        toast.style.display = 'none';
+        if (callback) callback();
+      }, 3000);
     }
     function hideToast(id) {
       document.getElementById(id).style.display = 'none';


### PR DESCRIPTION
## Summary
- Add callback-aware toast to trigger redirect after product creation
- Redirect to product list after showing success toast

## Testing
- `php -l application/views/adicionar_produto.php`
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b1580bd88322853ddacb31f63d87