### PR TITLE
Load product categories from database

### DIFF
--- a/application/controllers/Produtos.php
+++ b/application/controllers/Produtos.php
@@ -6,6 +6,7 @@ class Produtos extends CI_Controller {
     {
         parent::__construct();
         $this->load->model('Produto_model');
+        $this->load->model('Categoria_model');
     }
 
     public function lista()
@@ -16,7 +17,8 @@ class Produtos extends CI_Controller {
 
     public function adicionar()
     {
-        $this->load->view('adicionar_produto');
+        $data['categorias'] = $this->Categoria_model->todas();
+        $this->load->view('adicionar_produto', $data);
     }
 
     public function salvar()

--- a/application/migrations/20240516120000_create_categorias.php
+++ b/application/migrations/20240516120000_create_categorias.php
@@ -1,0 +1,33 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migration_Create_categorias extends CI_Migration {
+    public function up()
+    {
+        $this->dbforge->add_field([
+            'id' => [
+                'type' => 'INT',
+                'constraint' => 11,
+                'unsigned' => TRUE,
+                'auto_increment' => TRUE,
+            ],
+            'nome' => [
+                'type' => 'VARCHAR',
+                'constraint' => '100',
+            ],
+        ]);
+        $this->dbforge->add_key('id', TRUE);
+        $this->dbforge->create_table('categorias');
+
+        $categorias = [];
+        for ($i = 1; $i <= 5; $i++) {
+            $categorias[] = ['nome' => 'Categoria ' . $i];
+        }
+        $this->db->insert_batch('categorias', $categorias);
+    }
+
+    public function down()
+    {
+        $this->dbforge->drop_table('categorias');
+    }
+}

--- a/application/models/Categoria_model.php
+++ b/application/models/Categoria_model.php
@@ -1,0 +1,13 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Categoria_model extends CI_Model {
+    public function __construct() {
+        parent::__construct();
+        $this->load->database();
+    }
+
+    public function todas() {
+        return $this->db->get('categorias')->result();
+    }
+}

--- a/application/views/adicionar_produto.php
+++ b/application/views/adicionar_produto.php
@@ -32,10 +32,9 @@
               <label for="categoria" class="form-label">Categoria</label>
               <select class="form-select" id="categoria" name="categoria" required>
                 <option value="" selected disabled>Selecione uma categoria</option>
-                <option value="Lubrificantes">Lubrificantes</option>
-                <option value="Filtros">Filtros</option>
-                <option value="Freios">Freios</option>
-                <option value="Acessórios">Acessórios</option>
+                <?php foreach ($categorias as $categoria): ?>
+                  <option value="<?= $categoria->nome; ?>"><?= $categoria->nome; ?></option>
+                <?php endforeach; ?>
               </select>
             </div>
             <div class="mb-3">

--- a/database/categorias.sql
+++ b/database/categorias.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `categorias` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `nome` varchar(100) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `categorias` (`nome`) VALUES
+('Categoria 1'),
+('Categoria 2'),
+('Categoria 3'),
+('Categoria 4'),
+('Categoria 5');


### PR DESCRIPTION
## Summary
- Create migration and SQL to manage categories and seed sample records
- Add model and controller logic to fetch categories for the product form
- Populate Add Product form with categories from the database

## Testing
- `php -l application/migrations/20240516120000_create_categorias.php`
- `php -l application/models/Categoria_model.php`
- `php -l application/controllers/Produtos.php`
- `php -l application/views/adicionar_produto.php`
- `composer install --no-interaction --no-progress` (fails: CONNECT tunnel failed, response 403)
- `composer test:coverage` (fails: phpunit: not found)


------
https://chatgpt.com/codex/tasks/task_e_68a5be07cb288322aae95614f25335ce