### PR TITLE
feat: add client service history modal

### DIFF
--- a/application/controllers/Clientes.php
+++ b/application/controllers/Clientes.php
@@ -77,4 +77,21 @@ class Clientes extends CI_Controller {
             ->set_status_header($success ? 200 : 500)
             ->set_output(json_encode(['status' => $success ? 'success' : 'error']));
     }
+
+    public function historico($id)
+    {
+        $this->load->model('Cliente_model');
+        $this->load->model('Venda_model');
+
+        $cliente = $this->Cliente_model->get($id);
+        if (!$cliente) {
+            show_404();
+        }
+
+        $historico = $this->Venda_model->por_cliente($cliente['nome']);
+
+        $this->output
+            ->set_content_type('application/json')
+            ->set_output(json_encode($historico));
+    }
 }

--- a/application/models/Venda_model.php
+++ b/application/models/Venda_model.php
@@ -24,4 +24,12 @@ class Venda_model extends CI_Model {
     public function todas() {
         return $this->db->order_by('data', 'DESC')->get('vendas')->result();
     }
+
+    public function por_cliente($cliente)
+    {
+        return $this->db
+            ->order_by('data', 'DESC')
+            ->get_where('vendas', ['cliente' => $cliente])
+            ->result_array();
+    }
 }

--- a/application/views/lista_clientes.php
+++ b/application/views/lista_clientes.php
@@ -39,7 +39,7 @@
                 <td>
                     <button class="btn btn-sm btn-primary me-1" onclick="window.location.href='<?= site_url('clientes/editar/'.$c['id']); ?>'"><i class="bi bi-pencil"></i></button>
                     <button class="btn btn-sm btn-danger me-1" data-bs-toggle="modal" data-bs-target="#confirmDeleteModal" data-id="<?= $c['id']; ?>"><i class="bi bi-trash"></i></button>
-                    <button class="btn btn-sm btn-secondary" data-bs-toggle="modal" data-bs-target="#historyModal"><i class="bi bi-clock-history"></i></button>
+                    <button class="btn btn-sm btn-secondary" data-bs-toggle="modal" data-bs-target="#historyModal" data-id="<?= $c['id']; ?>"><i class="bi bi-clock-history"></i></button>
                 </td>
               </tr>
             <?php endforeach; ?>
@@ -79,10 +79,7 @@
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
-          <ul class="list-group">
-            <li class="list-group-item">01/01/2024 - Cliente cadastrado.</li>
-            <li class="list-group-item">15/01/2024 - Dados atualizados.</li>
-          </ul>
+          <ul class="list-group" id="historyList"></ul>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fechar</button>
@@ -130,6 +127,32 @@
           },
           error: function () {
             alert('Erro ao apagar cliente');
+          }
+        });
+      });
+
+      $('#historyModal').on('show.bs.modal', function (event) {
+        const button = $(event.relatedTarget);
+        const cliente = button.data('id');
+        const list = $('#historyList');
+        list.html('<li class="list-group-item">Carregando...</li>');
+
+        $.ajax({
+          url: '<?= site_url('clientes/historico'); ?>/' + cliente,
+          dataType: 'json',
+          success: function (data) {
+            list.empty();
+            if (!data || data.length === 0) {
+              list.append('<li class="list-group-item">Nenhum serviço encontrado.</li>');
+            } else {
+              data.forEach(function (item) {
+                const desc = item.descricao ? item.descricao : item.produto;
+                list.append('<li class="list-group-item">' + item.data + ' - ' + desc + '</li>');
+              });
+            }
+          },
+          error: function () {
+            list.html('<li class="list-group-item text-danger">Erro ao carregar histórico.</li>');
           }
         });
       });


### PR DESCRIPTION
## Summary
- add Venda_model::por_cliente to fetch sales by client
- expose Clientes::historico endpoint returning client service history
- show fetched history in Lista de Clientes modal via AJAX

## Testing
- `php -l application/models/Venda_model.php`
- `php -l application/controllers/Clientes.php`
- `php -l application/views/lista_clientes.php`


------
https://chatgpt.com/codex/tasks/task_e_68aa5d8fdc508322a5c608661d67a72a