### PR TITLE
feat: add three-level login

### DIFF
--- a/application/config/autoload.php
+++ b/application/config/autoload.php
@@ -58,7 +58,7 @@ $autoload['packages'] = array();
 |
 |	$autoload['libraries'] = array('user_agent' => 'ua');
 */
-$autoload['libraries'] = array('database');
+$autoload['libraries'] = array('database', 'session');
 
 /*
 | -------------------------------------------------------------------

--- a/application/controllers/Auth.php
+++ b/application/controllers/Auth.php
@@ -1,0 +1,43 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Auth extends CI_Controller {
+    private $users = [
+        ['username' => 'admin', 'password' => 'admin123', 'level' => '1'],
+        ['username' => 'manager', 'password' => 'manager123', 'level' => '2'],
+        ['username' => 'user', 'password' => 'user123', 'level' => '3'],
+    ];
+
+    public function login()
+    {
+        $this->load->view('login');
+    }
+
+    public function do_login()
+    {
+        $username = $this->input->post('username');
+        $password = $this->input->post('password');
+        $level    = $this->input->post('level');
+
+        foreach ($this->users as $user) {
+            if ($user['username'] === $username && $user['password'] === $password && $user['level'] === $level) {
+                $this->session->set_userdata([
+                    'logged_in' => TRUE,
+                    'username'  => $username,
+                    'level'     => $level,
+                ]);
+                redirect('home');
+                return;
+            }
+        }
+
+        $this->session->set_flashdata('error', 'Credenciais inválidas.');
+        redirect('auth/login');
+    }
+
+    public function logout()
+    {
+        $this->session->sess_destroy();
+        redirect('auth/login');
+    }
+}

--- a/application/controllers/Home.php
+++ b/application/controllers/Home.php
@@ -2,6 +2,14 @@
 defined('BASEPATH') OR exit('No direct script access allowed');
 
 class Home extends CI_Controller {
+    public function __construct()
+    {
+        parent::__construct();
+        if (!$this->session->userdata('logged_in')) {
+            redirect('auth/login');
+        }
+    }
+
     public function index()
     {
         $this->load->view('home');

--- a/application/views/login.php
+++ b/application/views/login.php
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Login | SIGE</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="d-flex justify-content-center align-items-center min-vh-100 bg-light text-dark">
+  <div class="card p-4 shadow-sm" style="min-width:300px;">
+    <h3 class="mb-3 text-center">Login</h3>
+    <?php if($this->session->flashdata('error')): ?>
+      <div class="alert alert-danger"><?php echo $this->session->flashdata('error'); ?></div>
+    <?php endif; ?>
+    <form method="post" action="<?= site_url('auth/do_login'); ?>">
+      <div class="mb-3">
+        <label class="form-label">Usuário</label>
+        <input type="text" name="username" class="form-control" required>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Senha</label>
+        <input type="password" name="password" class="form-control" required>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Nível</label>
+        <select name="level" class="form-select">
+          <option value="1">Administrador</option>
+          <option value="2">Gerente</option>
+          <option value="3">Funcionário</option>
+        </select>
+      </div>
+      <button type="submit" class="btn btn-primary w-100">Entrar</button>
+    </form>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/application/views/navbar.php
+++ b/application/views/navbar.php
@@ -12,7 +12,8 @@
     <div class="d-flex align-items-center">
       <!-- User profile icon and greeting -->
       <i class="bi bi-person-circle fs-3 me-2 text-primary"></i>
-      <span>Olá, Administrador</span>
+      <span>Olá, <?= html_escape($this->session->userdata('username')); ?></span>
+      <a href="<?= site_url('auth/logout'); ?>" class="btn btn-sm btn-outline-secondary ms-3">Sair</a>
     </div>
   </div>
 </nav>


### PR DESCRIPTION
## Summary
- add basic multi-level login with three user levels and session handling
- restrict dashboard access to authenticated users and show logout option
- autoload session library for authentication

## Testing
- `php -l application/controllers/Auth.php`
- `php -l application/controllers/Home.php`
- `php -l application/views/navbar.php`
- `php -l application/views/login.php`
- `php -l application/config/autoload.php`
- `composer install` *(failed: curl error 56 while downloading packages)*
- `vendor/bin/phpunit` *(failed: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6c0241148322a9585967f36d0d11