### PR TITLE
Bloquear acesso para usuários sem sessão em níveis válidos

### DIFF
--- a/application/controllers/Caixa.php
+++ b/application/controllers/Caixa.php
@@ -1,7 +1,7 @@
 <?php
 defined('BASEPATH') OR exit('No direct script access allowed');
 
-class Caixa extends CI_Controller {
+class Caixa extends MY_Controller {
     public function __construct()
     {
         parent::__construct();

--- a/application/controllers/Clientes.php
+++ b/application/controllers/Clientes.php
@@ -1,7 +1,7 @@
 <?php
 defined('BASEPATH') OR exit('No direct script access allowed');
 
-class Clientes extends CI_Controller {
+class Clientes extends MY_Controller {
 
     public function lista()
     {

--- a/application/controllers/Home.php
+++ b/application/controllers/Home.php
@@ -1,15 +1,7 @@
 <?php
 defined('BASEPATH') OR exit('No direct script access allowed');
 
-class Home extends CI_Controller {
-    public function __construct()
-    {
-        parent::__construct();
-        if (!$this->session->userdata('logged_in')) {
-            redirect('auth/login');
-        }
-    }
-
+class Home extends MY_Controller {
     public function index()
     {
         $this->load->view('home');

--- a/application/controllers/Produtos.php
+++ b/application/controllers/Produtos.php
@@ -1,7 +1,7 @@
 <?php
 defined('BASEPATH') OR exit('No direct script access allowed');
 
-class Produtos extends CI_Controller {
+class Produtos extends MY_Controller {
     public function __construct()
     {
         parent::__construct();

--- a/application/controllers/Relatorios.php
+++ b/application/controllers/Relatorios.php
@@ -1,7 +1,7 @@
 <?php
 defined('BASEPATH') OR exit('No direct script access allowed');
 
-class Relatorios extends CI_Controller {
+class Relatorios extends MY_Controller {
     public function vendas()
     {
         $this->load->model('Venda_model');

--- a/application/core/MY_Controller.php
+++ b/application/core/MY_Controller.php
@@ -1,0 +1,15 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class MY_Controller extends CI_Controller {
+    public function __construct()
+    {
+        parent::__construct();
+        $allowed_levels = ['1', '2', '3'];
+        $logged_in = $this->session->userdata('logged_in');
+        $level = $this->session->userdata('level');
+        if (!$logged_in || !in_array($level, $allowed_levels)) {
+            redirect('auth/login');
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Criado `MY_Controller` para verificar se a sessão foi iniciada com nível 1, 2 ou 3
- Atualizados os controladores para herdar de `MY_Controller`

## Testing
- `php -l application/core/MY_Controller.php && php -l application/controllers/Home.php && php -l application/controllers/Caixa.php && php -l application/controllers/Clientes.php && php -l application/controllers/Produtos.php && php -l application/controllers/Relatorios.php`

------
https://chatgpt.com/codex/tasks/task_e_68aaf2fa4c0c83228438282cd831b5c8