### PR TITLE
Remove level selection from login form

### DIFF
--- a/application/controllers/Auth.php
+++ b/application/controllers/Auth.php
@@ -17,14 +17,13 @@ class Auth extends CI_Controller {
     {
         $username = $this->input->post('username');
         $password = $this->input->post('password');
-        $level    = $this->input->post('level');
 
         foreach ($this->users as $user) {
-            if ($user['username'] === $username && $user['password'] === $password && $user['level'] === $level) {
+            if ($user['username'] === $username && $user['password'] === $password) {
                 $this->session->set_userdata([
                     'logged_in' => TRUE,
                     'username'  => $username,
-                    'level'     => $level,
+                    'level'     => $user['level'],
                 ]);
                 redirect('home');
                 return;

--- a/application/views/login.php
+++ b/application/views/login.php
@@ -21,14 +21,7 @@
         <label class="form-label">Senha</label>
         <input type="password" name="password" class="form-control" required>
       </div>
-      <div class="mb-3">
-        <label class="form-label">Nível</label>
-        <select name="level" class="form-select">
-          <option value="1">Administrador</option>
-          <option value="2">Gerente</option>
-          <option value="3">Funcionário</option>
-        </select>
-      </div>
+      
       <button type="submit" class="btn btn-primary w-100">Entrar</button>
     </form>
   </div>


### PR DESCRIPTION
## Summary
- Remove manual level dropdown from login form
- Automatically set user level after validating credentials

## Testing
- `php -l application/views/login.php`
- `php -l application/controllers/Auth.php`


------
https://chatgpt.com/codex/tasks/task_e_68aaf9806b0483229aaef55fde19d95e