### PR TITLE
Delay redirect after sale to show toast

### DIFF
--- a/application/views/nova_venda.php
+++ b/application/views/nova_venda.php
@@ -131,7 +131,9 @@
         .then(data => {
           if (data.status === 'success') {
             showToast('toast-success');
-            form.reset();
+            setTimeout(() => {
+              window.location.href = "<?= site_url('produtos/lista'); ?>";
+            }, 3000);
             descDiv.classList.add('d-none');
             descInput.required = false;
           } else {


### PR DESCRIPTION
## Summary
- Delay redirect after recording a sale to show success toast
- Remove unnecessary form reset on sale success

## Testing
- `php -l application/views/nova_venda.php`


------
https://chatgpt.com/codex/tasks/task_e_68ab00ba12508322a744da7b14fba61a