### PR TITLE
Fix DataTables warning when adding saída

### DIFF
--- a/application/views/saidas.php
+++ b/application/views/saidas.php
@@ -117,10 +117,15 @@
           if (data.status === 'success') {
             showToast('toast-success');
             const dataFormatada = new Date(formData.get('data')).toLocaleDateString('pt-PT');
+            const valor = parseFloat(formData.get('valor'));
             tabela.row.add([
               dataFormatada,
               formData.get('descricao'),
-              parseFloat(formData.get('valor')).toLocaleString('pt-BR', {minimumFractionDigits: 2, maximumFractionDigits: 2})
+              {
+                display: valor.toLocaleString('pt-BR', {minimumFractionDigits: 2, maximumFractionDigits: 2}),
+                sort: valor,
+                filter: valor.toLocaleString('pt-BR', {minimumFractionDigits: 2, maximumFractionDigits: 2})
+              }
             ]).draw();
             form.reset();
           } else {


### PR DESCRIPTION
## Summary
- ensure newly added Saída rows provide DataTables with explicit display/sort values for the Valor column to avoid `[object Object]` errors

## Testing
- `composer test:coverage` *(fails: phpunit: not found)*
- `composer install` *(fails: curl error 56, CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1c29e6f083228074705aacac0523