### PR TITLE
Fix DataTables row addition on Saidas page

### DIFF
--- a/application/views/saidas.php
+++ b/application/views/saidas.php
@@ -118,15 +118,13 @@
             showToast('toast-success');
             const dataFormatada = new Date(formData.get('data')).toLocaleDateString('pt-PT');
             const valor = parseFloat(formData.get('valor'));
-            tabela.row.add([
+            const valorFormatado = valor.toLocaleString('pt-BR', {minimumFractionDigits: 2, maximumFractionDigits: 2});
+            const novaLinha = tabela.row.add([
               dataFormatada,
               formData.get('descricao'),
-              {
-                display: valor.toLocaleString('pt-BR', {minimumFractionDigits: 2, maximumFractionDigits: 2}),
-                sort: valor,
-                filter: valor.toLocaleString('pt-BR', {minimumFractionDigits: 2, maximumFractionDigits: 2})
-              }
-            ]).draw();
+              valorFormatado
+            ]).draw().node();
+            $(novaLinha).find('td:eq(2)').attr('data-order', valor);
             form.reset();
           } else {
             showToast('toast-error');


### PR DESCRIPTION
## Summary
- prevent DataTables from receiving objects when adding new rows on Saídas page
- set `data-order` on newly added rows to maintain numeric sorting

## Testing
- `php -l application/views/saidas.php`
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac25ca0d74832282fe69c2eff41bce