### PR TITLE
Fix DataTables warning on Saídas page

### DIFF
--- a/application/views/saidas.php
+++ b/application/views/saidas.php
@@ -118,14 +118,11 @@
             showToast('toast-success');
             const dataFormatada = new Date(formData.get('data')).toLocaleDateString('pt-PT');
             const valor = parseFloat(formData.get('valor'));
+            const valorFormatado = valor.toLocaleString('pt-BR', {minimumFractionDigits: 2, maximumFractionDigits: 2});
             tabela.row.add([
               dataFormatada,
               formData.get('descricao'),
-              {
-                display: valor.toLocaleString('pt-BR', {minimumFractionDigits: 2, maximumFractionDigits: 2}),
-                sort: valor,
-                filter: valor.toLocaleString('pt-BR', {minimumFractionDigits: 2, maximumFractionDigits: 2})
-              }
+              `<span data-order="${valor}">${valorFormatado}</span>`
             ]).draw();
             form.reset();
           } else {


### PR DESCRIPTION
## Summary
- embed formatted value with `data-order` span when adding new Saídas rows to DataTable to avoid object parameter warning and preserve numeric sorting

## Testing
- `php -l application/views/saidas.php`
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac25ca0d74832282fe69c2eff41bce