### PR TITLE
Handle DataTables row ordering without span in saidas table

### DIFF
--- a/application/views/saidas.php
+++ b/application/views/saidas.php
@@ -122,8 +122,10 @@
             tabela.row.add([
               dataFormatada,
               formData.get('descricao'),
-              `<span data-order="${valor}">${valorFormatado}</span>`
+              valorFormatado
             ]).draw();
+            const novaLinha = tabela.row(':last').node();
+            novaLinha.querySelector('td:nth-child(3)')?.setAttribute('data-order', valor);
             form.reset();
           } else {
             showToast('toast-error');


### PR DESCRIPTION
## Summary
- Replace inline span with formatted value string when adding rows
- After drawing, set `data-order` on the third cell to maintain numeric sorting

## Testing
- `php -l application/views/saidas.php`
- *(attempted)* `npm install jsdom jquery datatables.net` *(failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2ba041608322b6b1550de615ed29