### PR TITLE
Fix DataTables data-order handling for Saídas

### DIFF
--- a/application/views/saidas.php
+++ b/application/views/saidas.php
@@ -124,8 +124,8 @@
               formData.get('descricao'),
               valorFormatado
             ]).draw();
-            const novaLinha = tabela.row(':last').node();
-            novaLinha.querySelector('td:nth-child(3)')?.setAttribute('data-order', valor);
+            const node = tabela.row(':last').node();
+            $(node).find('td').eq(2).attr('data-order', valor);
             form.reset();
           } else {
             showToast('toast-error');


### PR DESCRIPTION
## Summary
- Replace span-wrapped value with plain formatted amount in new Saída rows
- After insertion, set `data-order` on the third cell via jQuery to preserve sorting

## Testing
- `php -l application/views/saidas.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac2d2290a48322a0c9c9f89a1a47fe