### PR TITLE
Ensure DataTable rows maintain sorting attribute

### DIFF
--- a/application/views/saidas.php
+++ b/application/views/saidas.php
@@ -104,6 +104,12 @@
         }
       });
 
+      tabela.rows().nodes().each((rowNode) => {
+        const cell = $(rowNode).find('td').eq(2);
+        const orderValue = parseFloat(cell.text().replace(/\./g, '').replace(',', '.'));
+        cell.attr('data-order', orderValue);
+      });
+
       const form = document.getElementById('saidaForm');
       form.addEventListener('submit', function (e) {
         e.preventDefault();
@@ -126,6 +132,11 @@
             ]).draw();
             const node = tabela.row(':last').node();
             $(node).find('td').eq(2).attr('data-order', valor);
+            tabela.rows().nodes().each((rowNode) => {
+              const cell = $(rowNode).find('td').eq(2);
+              const orderValue = parseFloat(cell.text().replace(/\./g, '').replace(',', '.'));
+              cell.attr('data-order', orderValue);
+            });
             form.reset();
           } else {
             showToast('toast-error');


### PR DESCRIPTION
## Summary
- Ensure DataTables initializes with numeric `data-order` attributes for all value cells
- Update form submission to set `data-order` on new rows and reapply to all rows

## Testing
- `php -l application/views/saidas.php`
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `composer test:coverage` *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2f3c074883229da35f1b03e6d34e