### PR TITLE
Fix sidebar assets on Saídas page

### DIFF
--- a/application/views/saidas.php
+++ b/application/views/saidas.php
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Saídas | SIGE</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
   <link href="<?= base_url('assets/style.css'); ?>" rel="stylesheet">
 </head>
 <body class="d-flex min-vh-100 bg-light text-dark">
@@ -35,5 +36,7 @@
     </div>
   </div>
 </div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="<?= base_url('assets/layout.js'); ?>"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Include Bootstrap Icons and sidebar layout script on Saídas view
- Load Bootstrap JavaScript bundle to enable sidebar behavior

## Testing
- `php -l application/views/saidas.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac38f744208322be06ec564ff03020