### PR TITLE
Padroniza tabelas com DataTables

### DIFF
--- a/application/views/fluxo_caixa.php
+++ b/application/views/fluxo_caixa.php
@@ -67,7 +67,7 @@
       </div>
 
       <div class="table-responsive">
-        <table class="table table-striped table-hover align-middle" id="tabelaFluxo">
+        <table class="table table-striped table-hover align-middle datatable" id="tabelaFluxo">
           <thead class="table-light">
             <tr>
               <th>Data</th>
@@ -114,18 +114,13 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/pdfmake.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/vfs_fonts.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="<?= base_url('assets/tables.js'); ?>"></script>
   <script>
     $(document).ready(function () {
-      const tabela = $('#tabelaFluxo').DataTable({
-        dom: 'Brtip',
-        buttons: ['copy', 'csv', 'excel', 'pdf', 'print'],
-        language: {
-          url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-PT.json'
-        }
+      const tabela = $('#tabelaFluxo').DataTable();
+      $('#tabelaFluxoSearch').on('keyup', function () {
+        tabela.search(this.value).draw();
       });
-        $('#tabelaFluxoSearch').on('keyup', function () {
-          tabela.search(this.value).draw();
-        });
 
 
       function calcularTotais() {

--- a/application/views/home.php
+++ b/application/views/home.php
@@ -6,7 +6,9 @@
   <title>Painel de Controle | SIGE</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
-  <link href="<?= base_url('assets/style.css'); ?>" rel="stylesheet">  
+  <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css">
+  <link rel="stylesheet" href="https://cdn.datatables.net/buttons/2.4.1/css/buttons.bootstrap5.min.css">
+  <link href="<?= base_url('assets/style.css'); ?>" rel="stylesheet">
 </head>
 <body class="d-flex min-vh-100 bg-light text-dark">
 <?php $this->load->view('navbar'); ?>
@@ -58,7 +60,7 @@
 
   <div class="table-responsive mt-4">
     <h5 class="mb-3">Últimos Clientes</h5>
-    <table class="table table-striped table-hover align-middle">
+    <table class="table table-bordered table-striped table-hover align-middle datatable">
       <thead class="table-light">
           <tr>
             <th>#</th>
@@ -88,6 +90,17 @@
   </div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.7.0.min.js"></script>
+<script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+<script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
+<script src="https://cdn.datatables.net/buttons/2.4.1/js/dataTables.buttons.min.js"></script>
+<script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.bootstrap5.min.js"></script>
+<script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.html5.min.js"></script>
+<script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.print.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.3/jszip.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/pdfmake.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/vfs_fonts.js"></script>
+<script src="<?= base_url('assets/tables.js'); ?>"></script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script src="<?= base_url('assets/script.js'); ?>"></script>
 <script src="<?= base_url('assets/layout.js'); ?>"></script>

--- a/application/views/lista_clientes.php
+++ b/application/views/lista_clientes.php
@@ -19,7 +19,7 @@
       <div class="card shadow-sm">
         <div class="card-body">
           <div class="table-responsive">
-          <table class="table table-bordered table-striped" id="tabelaClientes">
+          <table class="table table-bordered table-striped datatable" id="tabelaClientes">
             <thead class="table-light">
                 <tr>
                 <th>#</th>
@@ -100,17 +100,10 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.3/jszip.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/pdfmake.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/vfs_fonts.js"></script>
+  <script src="<?= base_url('assets/tables.js'); ?>"></script>
   <script>
     $(document).ready(function () {
-      if (!$.fn.DataTable.isDataTable('#tabelaClientes')) {
-        $('#tabelaClientes').DataTable({
-          dom: "<'d-flex justify-content-between align-items-center flex-wrap mb-3'<'d-flex align-items-center gap-2'lf>B>rtip",
-          buttons: ['copy', 'csv', 'excel', 'pdf', 'print'],
-          language: {
-            url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-PT.json'
-          }
-        });
-      }
+      const tabela = $('#tabelaClientes').DataTable();
 
       let clienteId;
       $('#confirmDeleteModal').on('show.bs.modal', function (event) {

--- a/application/views/lista_produtos.php
+++ b/application/views/lista_produtos.php
@@ -19,7 +19,7 @@
       <div class="card shadow-sm">
         <div class="card-body">
           <div class="table-responsive">
-          <table class="table table-bordered table-striped" id="tabelaProdutos">
+          <table class="table table-bordered table-striped datatable" id="tabelaProdutos">
             <thead class="table-light">
               <tr>
                 <th>#</th>
@@ -145,21 +145,10 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.3/jszip.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/pdfmake.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/vfs_fonts.js"></script>
+  <script src="<?= base_url('assets/tables.js'); ?>"></script>
   <script>
     $(document).ready(function () {
-      let tabela;
-      if (!$.fn.DataTable.isDataTable('#tabelaProdutos')) {
-        tabela = $('#tabelaProdutos').DataTable({
-          dom: "<'d-flex justify-content-between align-items-center flex-wrap mb-3'<'d-flex align-items-center gap-2'lf>B>rtip",
-          buttons: ['copy', 'csv', 'excel', 'pdf', 'print'],
-          language: {
-            url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-PT.json',
-            emptyTable: 'Nenhum produto cadastrado.'
-          }
-        });
-      } else {
-        tabela = $('#tabelaProdutos').DataTable();
-      }
+      const tabela = $('#tabelaProdutos').DataTable();
 
         const infoModal = document.getElementById('infoModal');
         infoModal.addEventListener('show.bs.modal', function (event) {

--- a/application/views/relatorios_caixa.php
+++ b/application/views/relatorios_caixa.php
@@ -32,7 +32,7 @@
       </div>
 
       <div class="table-responsive">
-        <table class="table table-striped table-hover align-middle" id="tabelaRelCaixa">
+        <table class="table table-striped table-hover align-middle datatable" id="tabelaRelCaixa">
           <thead class="table-light">
             <tr>
               <th>Período</th>
@@ -77,6 +77,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.3/jszip.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/pdfmake.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/vfs_fonts.js"></script>
+  <script src="<?= base_url('assets/tables.js'); ?>"></script>
   <script>
     $(document).ready(function () {
       const filtro = $('#filtroCaixa');
@@ -127,13 +128,7 @@
         return inicioPeriodo < fim && fimPeriodo >= inicio;
       });
 
-      const tabela = $('#tabelaRelCaixa').DataTable({
-        dom: "<'d-flex justify-content-between align-items-center flex-wrap mb-3'<'d-flex align-items-center gap-2'lf>B>rtip",
-        buttons: ['copy', 'csv', 'excel', 'pdf', 'print'],
-        language: {
-          url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-PT.json'
-        }
-      });
+      const tabela = $('#tabelaRelCaixa').DataTable();
 
       filtro.on('change', function () {
         tabela.draw();

--- a/application/views/relatorios_estoque.php
+++ b/application/views/relatorios_estoque.php
@@ -32,7 +32,7 @@
       </div>
 
       <div class="table-responsive">
-        <table class="table table-striped table-hover align-middle" id="tabelaEstoque">
+        <table class="table table-striped table-hover align-middle datatable" id="tabelaEstoque">
           <thead class="table-light">
             <tr>
               <th>Produto</th>
@@ -148,6 +148,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.3/jszip.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/pdfmake.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/vfs_fonts.js"></script>
+  <script src="<?= base_url('assets/tables.js'); ?>"></script>
   <script>
     $(document).ready(function () {
       const filtro = $('#filtroEstoque');
@@ -196,13 +197,7 @@
         return datas.some(d => d >= inicio && d < fim);
       });
 
-      const tabela = $('#tabelaEstoque').DataTable({
-        dom: "<'d-flex justify-content-between align-items-center flex-wrap mb-3'<'d-flex align-items-center gap-2'lf>B>rtip",
-        buttons: ['copy', 'csv', 'excel', 'pdf', 'print'],
-        language: {
-          url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-PT.json'
-        }
-      });
+      const tabela = $('#tabelaEstoque').DataTable();
 
       filtro.on('change', function () {
         tabela.draw();

--- a/application/views/relatorios_fiscais.php
+++ b/application/views/relatorios_fiscais.php
@@ -32,7 +32,7 @@
       </div>
 
       <div class="table-responsive">
-        <table class="table table-striped table-hover align-middle" id="tabelaFiscais">
+        <table class="table table-striped table-hover align-middle datatable" id="tabelaFiscais">
           <thead class="table-light">
             <tr>
               <th>Mês</th>
@@ -71,6 +71,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.3/jszip.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/pdfmake.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/vfs_fonts.js"></script>
+  <script src="<?= base_url('assets/tables.js'); ?>"></script>
   <script>
     $(document).ready(function () {
       const filtro = $('#filtroFiscais');
@@ -133,13 +134,7 @@
         return inicioPeriodo < fim && fimPeriodo >= inicio;
       });
 
-      const tabela = $('#tabelaFiscais').DataTable({
-        dom: "<'d-flex justify-content-between align-items-center flex-wrap mb-3'<'d-flex align-items-center gap-2'lf>B>rtip",
-        buttons: ['copy', 'csv', 'excel', 'pdf', 'print'],
-        language: {
-          url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-PT.json'
-        }
-      });
+      const tabela = $('#tabelaFiscais').DataTable();
 
       filtro.on('change', function () {
         tabela.draw();

--- a/application/views/relatorios_vendas.php
+++ b/application/views/relatorios_vendas.php
@@ -32,7 +32,7 @@
       </div>
 
       <div class="table-responsive">
-        <table class="table table-striped table-hover align-middle" id="tabelaVendas">
+        <table class="table table-striped table-hover align-middle datatable" id="tabelaVendas">
           <thead class="table-light">
             <tr>
               <th>Produto</th>
@@ -71,6 +71,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.3/jszip.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/pdfmake.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/vfs_fonts.js"></script>
+  <script src="<?= base_url('assets/tables.js'); ?>"></script>
   <script>
     $(document).ready(function () {
       const filtro = $('#filtroVendas');
@@ -117,13 +118,7 @@
         return dataVenda >= inicio && dataVenda < fim;
       });
 
-      const tabela = $('#tabelaVendas').DataTable({
-        dom: "<'d-flex justify-content-between align-items-center flex-wrap mb-3'<'d-flex align-items-center gap-2'lf>B>rtip",
-        buttons: ['copy', 'csv', 'excel', 'pdf', 'print'],
-        language: {
-          url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-PT.json'
-        }
-      });
+      const tabela = $('#tabelaVendas').DataTable();
 
       filtro.on('change', function () {
         tabela.draw();

--- a/application/views/saidas.php
+++ b/application/views/saidas.php
@@ -6,6 +6,8 @@
   <title>Saídas | SIGE</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css">
+  <link rel="stylesheet" href="https://cdn.datatables.net/buttons/2.4.1/css/buttons.bootstrap5.min.css">
   <link href="<?= base_url('assets/style.css'); ?>" rel="stylesheet">
 </head>
 <body class="d-flex min-vh-100 bg-light text-dark">
@@ -15,7 +17,7 @@
   <div class="container mt-5">
     <h3>Saídas</h3>
     <div class="table-responsive">
-      <table class="table table-striped">
+      <table class="table table-bordered table-striped datatable">
         <thead>
           <tr>
             <th>Data</th>
@@ -37,6 +39,17 @@
   </div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.7.0.min.js"></script>
+<script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+<script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
+<script src="https://cdn.datatables.net/buttons/2.4.1/js/dataTables.buttons.min.js"></script>
+<script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.bootstrap5.min.js"></script>
+<script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.html5.min.js"></script>
+<script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.print.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.3/jszip.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/pdfmake.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/vfs_fonts.js"></script>
+<script src="<?= base_url('assets/tables.js'); ?>"></script>
 <script src="<?= base_url('assets/layout.js'); ?>"></script>
 </body>
 </html>

--- a/assets/tables.js
+++ b/assets/tables.js
@@ -1,0 +1,15 @@
+$(document).ready(function () {
+  $('table.datatable').each(function () {
+    const tabela = $(this);
+    if (!$.fn.DataTable.isDataTable(tabela)) {
+      tabela.DataTable({
+        dom: "<'d-flex justify-content-between align-items-center flex-wrap mb-3'<'d-flex align-items-center gap-2'lf>B>rtip",
+        buttons: ['copy', 'csv', 'excel', 'pdf', 'print'],
+        language: {
+          url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-PT.json',
+          emptyTable: 'Nenhum registro encontrado.'
+        }
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Sumário
- centraliza configuração do DataTables em `tables.js`
- aplica o padrão de tabela da lista de produtos em todas as telas

## Testes
- `php -l application/views/lista_produtos.php`
- `php -l application/views/lista_clientes.php`
- `php -l application/views/relatorios_vendas.php`
- `php -l application/views/fluxo_caixa.php`
- `php -l application/views/relatorios_caixa.php`
- `php -l application/views/relatorios_fiscais.php`
- `php -l application/views/relatorios_estoque.php`
- `php -l application/views/home.php`
- `php -l application/views/saidas.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac3cdb98188322a4a04ca5903e1eac