### PR TITLE
Ensure Bootstrap table styling in Cash Flow view

### DIFF
--- a/assets/tables.js
+++ b/assets/tables.js
@@ -8,7 +8,8 @@ $(document).ready(function () {
         language: {
           url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-PT.json',
           emptyTable: 'Nenhum registro encontrado.'
-        }
+        },
+        stripeClasses: []
       });
     }
   });


### PR DESCRIPTION
## Summary
- prevent DataTables from applying its own striping so Bootstrap 5 `table-striped` and `table-hover` classes style the Cash Flow table correctly

## Testing
- `node --check assets/tables.js`
- `php -l application/views/fluxo_caixa.php`
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4c09c7788322863c31e2b9c986a6