### PR TITLE
Gerar factura ao registrar venda

### DIFF
--- a/application/controllers/Caixa.php
+++ b/application/controllers/Caixa.php
@@ -25,8 +25,10 @@ class Caixa extends MY_Controller {
             'valor'      => $this->input->post('valor')
         ];
 
-        if ($this->Venda_model->inserir($venda)) {
-            echo json_encode(['status' => 'success']);
+        $id = $this->Venda_model->inserir($venda);
+
+        if ($id) {
+            echo json_encode(['status' => 'success', 'id' => $id, 'venda' => $venda]);
         } else {
             echo json_encode(['status' => 'error']);
         }

--- a/application/models/Venda_model.php
+++ b/application/models/Venda_model.php
@@ -11,6 +11,7 @@ class Venda_model extends CI_Model {
         $this->db->trans_start();
 
         $this->db->insert('vendas', $data);
+        $venda_id = $this->db->insert_id();
 
         $quantidade = (int) $data['quantidade'];
         $this->db->set('estoque', 'estoque - ' . $quantidade, false);
@@ -18,7 +19,7 @@ class Venda_model extends CI_Model {
         $this->db->update('produtos');
 
         $this->db->trans_complete();
-        return $this->db->trans_status();
+        return $this->db->trans_status() ? $venda_id : false;
     }
 
     public function todas() {

--- a/application/views/nova_venda.php
+++ b/application/views/nova_venda.php
@@ -90,6 +90,8 @@
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script src="<?= base_url('assets/layout.js'); ?>"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/pdfmake.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/vfs_fonts.js"></script>
   <script>
     function toggleLoading(show) {
       const spinner = document.getElementById('loadingSpinner');
@@ -160,6 +162,11 @@
         .then(response => response.json())
         .then(data => {
           if (data.status === 'success') {
+            const vendaInfo = Object.fromEntries(formData.entries());
+            vendaInfo.id = data.id;
+            if (confirm('Deseja imprimir a factura em PDF?')) {
+              gerarPdf(vendaInfo);
+            }
             showToast('toast-success');
             setTimeout(() => {
               window.location.href = "<?= site_url('produtos/lista'); ?>";
@@ -183,6 +190,30 @@
       const toast = document.getElementById(id);
       toast.style.display = 'block';
       setTimeout(() => { toast.style.display = 'none'; }, 3000);
+    }
+
+    function gerarPdf(venda) {
+      const total = Number(venda.quantidade) * Number(venda.valor);
+      const content = [
+        { text: 'Factura', style: 'header' },
+        { text: `Nº: ${venda.id}` },
+        { text: `Data: ${venda.data}` },
+        { text: `Cliente: ${venda.cliente}` },
+        { text: `Produto/Serviço: ${venda.produto}` }
+      ];
+      if (venda.descricao) {
+        content.push({ text: `Descrição: ${venda.descricao}` });
+      }
+      content.push({ text: `Quantidade: ${venda.quantidade}` });
+      content.push({ text: `Valor: Kz ${venda.valor}` });
+      content.push({ text: `Total: Kz ${total}` });
+      const docDefinition = {
+        content: content,
+        styles: {
+          header: { fontSize: 18, bold: true, marginBottom: 10 }
+        }
+      };
+      pdfMake.createPdf(docDefinition).open();
     }
 
     function hideToast(id) {


### PR DESCRIPTION
## Summary
- Retorna o ID da venda e dados necessários ao registrar venda.
- Adiciona confirmação opcional para imprimir factura em PDF após registrar.
- Cria geração simples de factura em PDF usando pdfmake no formulário de nova venda.

## Testing
- `php -l application/controllers/Caixa.php`
- `php -l application/models/Venda_model.php`
- `php -l application/views/nova_venda.php`
- `composer test:coverage` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac664c9130832296de8de248a7b4d8