### PR TITLE
Improve invoice PDF design

### DIFF
--- a/application/views/nova_venda.php
+++ b/application/views/nova_venda.php
@@ -194,24 +194,90 @@
 
     function gerarPdf(venda) {
       const total = Number(venda.quantidade) * Number(venda.valor);
-      const content = [
-        { text: 'Factura', style: 'header' },
-        { text: `Nº: ${venda.id}` },
-        { text: `Data: ${venda.data}` },
-        { text: `Cliente: ${venda.cliente}` },
-        { text: `Produto/Serviço: ${venda.produto}` }
-      ];
-      if (venda.descricao) {
-        content.push({ text: `Descrição: ${venda.descricao}` });
-      }
-      content.push({ text: `Quantidade: ${venda.quantidade}` });
-      content.push({ text: `Valor: Kz ${venda.valor}` });
-      content.push({ text: `Total: Kz ${total}` });
       const docDefinition = {
-        content: content,
+        content: [
+          {
+            columns: [
+              {
+                stack: [
+                  { text: 'Delicias das Ribeirinho', bold: true },
+                  { text: '0055 009 0252914701 85' },
+                  { text: 'Luanda' },
+                  { text: 'COQUEIRO' }
+                ]
+              },
+              { text: 'FATURA', style: 'invoiceTitle', alignment: 'right' }
+            ]
+          },
+          { text: '\n' },
+          {
+            columns: [
+              {
+                width: '*',
+                stack: [
+                  { text: 'Faturar a', bold: true, margin: [0, 0, 0, 5] },
+                  { text: venda.cliente }
+                ]
+              },
+              {
+                width: 'auto',
+                table: {
+                  body: [
+                    [{ text: 'Número de fatura', bold: true }, `INV-${String(venda.id).padStart(4, '0')}`],
+                    [{ text: 'Data da fatura', bold: true }, venda.data],
+                    [{ text: 'Data de vencimento', bold: true }, venda.data]
+                  ]
+                },
+                layout: 'noBorders'
+              }
+            ]
+          },
+          { text: '\n' },
+          {
+            table: {
+              widths: ['*', 'auto', 'auto', 'auto', 'auto'],
+              body: [
+                [
+                  { text: 'Descrição', bold: true },
+                  { text: 'Unidade', bold: true },
+                  { text: 'Quantidade', bold: true },
+                  { text: 'Taxa', bold: true },
+                  { text: 'Montante', bold: true }
+                ],
+                [
+                  venda.descricao ? venda.descricao : venda.produto,
+                  'un',
+                  venda.quantidade,
+                  Number(venda.valor).toFixed(2),
+                  total.toFixed(2)
+                ]
+              ]
+            }
+          },
+          {
+            columns: [
+              { text: '', width: '*' },
+              {
+                width: 'auto',
+                table: {
+                  body: [
+                    [{ text: 'Subtotal', bold: true }, total.toFixed(2)],
+                    [{ text: 'Total', bold: true }, total.toFixed(2)]
+                  ]
+                },
+                layout: 'noBorders'
+              }
+            ]
+          },
+          { text: 'Notas', style: 'notesTitle', margin: [0, 20, 0, 3] },
+          { text: 'Foi um prazer fazer negócio consigo.', margin: [0, 0, 0, 10] },
+          { text: 'Termos e Condições', style: 'notesTitle' }
+        ],
         styles: {
-          header: { fontSize: 18, bold: true, marginBottom: 10 }
-        }
+          invoiceTitle: { fontSize: 20, bold: true },
+          notesTitle: { bold: true }
+        },
+        defaultStyle: { fontSize: 10 }
       };
       pdfMake.createPdf(docDefinition).open();
     }


### PR DESCRIPTION
## Summary
- redesign invoice PDF generated in new sale to include company header, client/invoice metadata, item table, totals and notes

## Testing
- `php -l application/views/nova_venda.php`
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6ace6df483229bffb4bf46eb15f3