### PR TITLE
Substitui coluna Produto/Serviço por Produto na página Vendas

### DIFF
--- a/application/views/vendas.php
+++ b/application/views/vendas.php
@@ -23,7 +23,7 @@
             <th>Nº</th>
             <th>Data</th>
             <th>Cliente</th>
-            <th>Produto/Serviço</th>
+            <th>Produto</th>
             <th>Quantidade</th>
             <th>Valor (Kz)</th>
             <th>Ações</th>
@@ -35,7 +35,7 @@
             data-id="<?= $v->id; ?>"
             data-data="<?= $v->data; ?>"
             data-cliente="<?= htmlspecialchars($v->cliente, ENT_QUOTES, 'UTF-8'); ?>"
-            data-produto="<?= htmlspecialchars($v->produto_nome ? $v->produto_nome : $v->produto, ENT_QUOTES, 'UTF-8'); ?>"
+            data-produto="<?= htmlspecialchars($v->produto, ENT_QUOTES, 'UTF-8'); ?>"
             data-descricao="<?= htmlspecialchars($v->descricao, ENT_QUOTES, 'UTF-8'); ?>"
             data-quantidade="<?= $v->quantidade; ?>"
             data-valor="<?= $v->valor; ?>"
@@ -43,7 +43,7 @@
             <td><?= $v->id; ?></td>
             <td><?= date('d/m/Y', strtotime($v->data)); ?></td>
             <td><?= $v->cliente; ?></td>
-            <td><?= $v->produto_nome ? $v->produto_nome : ($v->descricao ? $v->descricao : $v->produto); ?></td>
+            <td><?= $v->produto; ?></td>
             <td><?= $v->quantidade; ?></td>
             <td><?= number_format($v->valor, 2, ',', '.'); ?></td>
             <td><button class="btn btn-sm btn-outline-primary imprimir"><i class="bi bi-printer"></i></button></td>


### PR DESCRIPTION
## Summary
- Removi a coluna **Produto/Serviço** da tabela de vendas
- Adicionei coluna **Produto** exibindo o campo `produto` da tabela `vendas`
- Atualizei o atributo `data-produto` para usar o novo campo

## Testing
- `php -l application/views/vendas.php`

------
https://chatgpt.com/codex/tasks/task_e_68af26557be083229dc7c51e7cc882e5