### PR TITLE
Format currency in PDF invoices

### DIFF
--- a/application/views/nova_venda.php
+++ b/application/views/nova_venda.php
@@ -182,6 +182,13 @@
       });
     }
 
+    function formatCurrency(value) {
+      return Number(value).toLocaleString('pt-PT', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2
+      }) + ' kz';
+    }
+
     async function gerarPdf(venda) {
       const logo = await getBase64ImageFromURL('<?= base_url('assets/logo.jpeg'); ?>');
       const total = Number(venda.quantidade) * Number(venda.valor);
@@ -240,8 +247,8 @@
                   venda.produto,
                   'un',
                   venda.quantidade,
-                  Number(venda.valor).toFixed(2),
-                  total.toFixed(2)
+                  formatCurrency(venda.valor),
+                  formatCurrency(total)
                 ]
               ]
             }
@@ -253,8 +260,8 @@
                 width: 'auto',
                 table: {
                   body: [
-                    [{ text: 'Subtotal', bold: true }, total.toFixed(2)],
-                    [{ text: 'Total', bold: true }, total.toFixed(2)]
+                    [{ text: 'Subtotal', bold: true }, formatCurrency(total)],
+                    [{ text: 'Total', bold: true }, formatCurrency(total)]
                   ]
                 },
                 layout: 'noBorders'

--- a/application/views/vendas.php
+++ b/application/views/vendas.php
@@ -79,6 +79,13 @@
       });
     }
 
+    function formatCurrency(value) {
+      return Number(value).toLocaleString('pt-PT', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2
+      }) + ' kz';
+    }
+
     async function gerarPdf(venda) {
       const logo = await getBase64ImageFromURL('<?= base_url('assets/logo.jpeg'); ?>');
       const total = Number(venda.quantidade) * Number(venda.valor);
@@ -137,8 +144,8 @@
                   venda.descricao ? venda.descricao : venda.produto,
                   'un',
                   venda.quantidade,
-                  Number(venda.valor).toFixed(2),
-                  total.toFixed(2)
+                  formatCurrency(venda.valor),
+                  formatCurrency(total)
                 ]
               ]
             }
@@ -150,8 +157,8 @@
                 width: 'auto',
                 table: {
                   body: [
-                    [{ text: 'Subtotal', bold: true }, total.toFixed(2)],
-                    [{ text: 'Total', bold: true }, total.toFixed(2)]
+                    [{ text: 'Subtotal', bold: true }, formatCurrency(total)],
+                    [{ text: 'Total', bold: true }, formatCurrency(total)]
                   ]
                 },
                 layout: 'noBorders'


### PR DESCRIPTION
## Summary
- Format numeric values in invoice PDFs using locale-specific thousands and decimals, appending `kz`
- Apply currency formatting to item price, totals, and PDF tables

## Testing
- `composer run-script test:coverage` *(fails: phpunit: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b01f69f07083229da6d7e16f0d5089