### PR TITLE
Add payment method field to new sale page

### DIFF
--- a/application/controllers/Caixa.php
+++ b/application/controllers/Caixa.php
@@ -34,7 +34,8 @@ class Caixa extends MY_Controller {
             'cliente'    => $cliente['nome'],
             'produto'    => $produto->nome,
             'quantidade' => $this->input->post('quantidade'),
-            'valor'      => $this->input->post('valor')
+            'valor'      => $this->input->post('valor'),
+            'forma_pagamento' => $this->input->post('forma_pagamento')
         ];
 
         $id = $this->Venda_model->inserir($venda);

--- a/application/views/nova_venda.php
+++ b/application/views/nova_venda.php
@@ -57,6 +57,14 @@
               <label for="valorVenda" class="form-label">Valor (Kz)</label>
               <input type="number" class="form-control" id="valorVenda" name="valor" required>
             </div>
+            <div class="mb-3">
+              <label for="formaPagamento" class="form-label">Forma de Pagamento</label>
+              <select class="form-select" id="formaPagamento" name="forma_pagamento" required>
+                <option value="TPA">TPA</option>
+                <option value="CASH">CASH</option>
+                <option value="Outro">Outro</option>
+              </select>
+            </div>
             <button type="submit" class="btn btn-primary"><i class="bi bi-save"></i> Registrar Venda</button>
           </form>
         </div>

--- a/database/vendas.sql
+++ b/database/vendas.sql
@@ -6,6 +6,7 @@ CREATE TABLE `vendas` (
   `descricao` varchar(255) DEFAULT NULL,
   `quantidade` int(11) NOT NULL,
   `valor` decimal(10,2) NOT NULL,
+  `forma_pagamento` varchar(20) NOT NULL,
   `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
## Summary
- add forma de pagamento select (TPA, CASH, Outro) to nova venda form
- capture and save forma_pagamento in Caixa controller and vendas table

## Testing
- `php -l application/views/nova_venda.php`
- `php -l application/controllers/Caixa.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0352ce398832299a62192269bdb6b