### PR TITLE
Adicionar forma de pagamento nas saídas

### DIFF
--- a/application/controllers/Saidas.php
+++ b/application/controllers/Saidas.php
@@ -24,7 +24,8 @@ class Saidas extends MY_Controller {
         $saida = [
             'data' => $this->input->post('data'),
             'descricao' => $this->input->post('descricao'),
-            'valor' => $this->input->post('valor')
+            'valor' => $this->input->post('valor'),
+            'forma_pagamento' => $this->input->post('forma_pagamento')
         ];
 
         if ($this->Saida_model->insert($saida)) {

--- a/application/views/fluxo_caixa.php
+++ b/application/views/fluxo_caixa.php
@@ -96,7 +96,7 @@
                   <td><?= htmlspecialchars($saida->descricao, ENT_QUOTES, 'UTF-8'); ?></td>
                   <td>-</td>
                   <td><span class="badge bg-danger">Saída</span></td>
-                  <td>-</td>
+                  <td><?= htmlspecialchars($saida->forma_pagamento, ENT_QUOTES, 'UTF-8'); ?></td>
                   <td data-order="<?= $saida->valor; ?>"><?= number_format($saida->valor, 2, ',', '.'); ?></td>
                 </tr>
                 <?php endforeach; ?>

--- a/application/views/nova_saida.php
+++ b/application/views/nova_saida.php
@@ -32,6 +32,16 @@
             <label for="valorSaida" class="form-label">Valor (Kz)</label>
             <input type="number" step="0.01" class="form-control" id="valorSaida" name="valor" required>
           </div>
+          <div class="mb-3">
+            <label for="formaPagamentoSaida" class="form-label">Forma de Pagamento</label>
+            <select class="form-select" id="formaPagamentoSaida" name="forma_pagamento" required>
+              <option value="TPA">TPA</option>
+              <option value="CASH">CASH</option>
+              <option value="Cartão Weza">Cartão Weza</option>
+              <option value="Cartão Sérgio">Cartão Sérgio</option>
+              <option value="Outro">Outro</option>
+            </select>
+          </div>
           <button type="submit" class="btn btn-primary"><i class="bi bi-save"></i> Registrar Saída</button>
         </form>
       </div>

--- a/application/views/saidas.php
+++ b/application/views/saidas.php
@@ -22,6 +22,7 @@
           <tr>
             <th>Data</th>
             <th>Descrição</th>
+            <th>Forma de Pagamento</th>
             <th>Valor (Kz)</th>
           </tr>
         </thead>
@@ -30,6 +31,7 @@
           <tr>
             <td><?= date('d/m/Y', strtotime($s->data)); ?></td>
             <td><?= htmlspecialchars($s->descricao, ENT_QUOTES, 'UTF-8'); ?></td>
+            <td><?= htmlspecialchars($s->forma_pagamento, ENT_QUOTES, 'UTF-8'); ?></td>
             <td><?= number_format($s->valor, 2, ',', '.'); ?></td>
           </tr>
           <?php endforeach; ?>

--- a/database/saidas.sql
+++ b/database/saidas.sql
@@ -3,6 +3,7 @@ CREATE TABLE `saidas` (
   `data` date NOT NULL,
   `descricao` varchar(255) NOT NULL,
   `valor` decimal(10,2) NOT NULL,
+  `forma_pagamento` varchar(20) NOT NULL,
   `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
## Summary
- permitir informar forma de pagamento ao registrar uma saída
- exibir forma de pagamento das saídas no fluxo de caixa e na listagem de saídas

## Testing
- `php -l application/controllers/Saidas.php`
- `php -l application/views/nova_saida.php`
- `php -l application/views/fluxo_caixa.php`
- `php -l application/views/saidas.php`


------
https://chatgpt.com/codex/tasks/task_e_68b04f4f649c832295318e18383803df