### PR TITLE
Allow registering multiple items in Nova Venda

### DIFF
--- a/application/controllers/Caixa.php
+++ b/application/controllers/Caixa.php
@@ -19,29 +19,47 @@ class Caixa extends MY_Controller {
     public function registrar_venda()
     {
         $cliente_nome = $this->input->post('cliente');
-        $produto_nome = $this->input->post('produto');
-
         $cliente = $this->Cliente_model->get_by_nome($cliente_nome);
-        $produto = $this->Produto_model->buscar_por_nome($produto_nome);
+        $produtos = $this->input->post('produtos');
+        $quantidades = $this->input->post('quantidades');
+        $valores = $this->input->post('valores');
+        $data_venda = $this->input->post('data');
+        $forma_pagamento = $this->input->post('forma_pagamento');
 
-        if (!$cliente || !$produto) {
-            echo json_encode(['status' => 'error', 'message' => 'Cliente ou produto inválido']);
+        if (!$cliente || !is_array($produtos)) {
+            echo json_encode(['status' => 'error', 'message' => 'Cliente ou produtos inválidos']);
             return;
         }
 
-        $venda = [
-            'data'       => $this->input->post('data'),
-            'cliente'    => $cliente['nome'],
-            'produto'    => $produto->nome,
-            'quantidade' => $this->input->post('quantidade'),
-            'valor'      => $this->input->post('valor'),
-            'forma_pagamento' => $this->input->post('forma_pagamento')
-        ];
+        $vendas = [];
+        foreach ($produtos as $i => $produto_nome) {
+            $produto = $this->Produto_model->buscar_por_nome($produto_nome);
+            if (!$produto) {
+                continue;
+            }
+            $venda = [
+                'data'       => $data_venda,
+                'cliente'    => $cliente['nome'],
+                'produto'    => $produto->nome,
+                'quantidade' => isset($quantidades[$i]) ? $quantidades[$i] : 0,
+                'valor'      => isset($valores[$i]) ? $valores[$i] : 0,
+                'forma_pagamento' => $forma_pagamento
+            ];
+            $id = $this->Venda_model->inserir($venda);
+            if ($id) {
+                $venda['id'] = $id;
+                $vendas[] = $venda;
+            }
+        }
 
-        $id = $this->Venda_model->inserir($venda);
-
-        if ($id) {
-            echo json_encode(['status' => 'success', 'id' => $id, 'venda' => $venda]);
+        if (!empty($vendas)) {
+            echo json_encode([
+                'status' => 'success',
+                'cliente' => $cliente['nome'],
+                'data' => $data_venda,
+                'forma_pagamento' => $forma_pagamento,
+                'vendas' => $vendas
+            ]);
         } else {
             echo json_encode(['status' => 'error']);
         }


### PR DESCRIPTION
## Summary
- allow adding multiple products/services in a single sale
- process arrays of items on the server when registering sales
- generate invoices with all sale items included

## Testing
- `php -l application/controllers/Caixa.php`
- `php -l application/views/nova_venda.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6dfd59ea48322b40a02f097f93918