### PR TITLE
fix: include quantity in cash flow and sales values

### DIFF
--- a/application/views/fluxo_caixa.php
+++ b/application/views/fluxo_caixa.php
@@ -67,13 +67,14 @@
               </thead>
               <tbody>
                 <?php foreach ($vendas as $venda): ?>
+                <?php $total = $venda->valor * $venda->quantidade; ?>
                 <tr>
                   <td><?= date('d/m/Y', strtotime($venda->data)); ?></td>
                   <td><?= htmlspecialchars($venda->produto, ENT_QUOTES, 'UTF-8'); ?></td>
                   <td><?= $venda->quantidade; ?></td>
                   <td><span class="badge bg-success">Entrada</span></td>
                   <td><?= htmlspecialchars($venda->forma_pagamento, ENT_QUOTES, 'UTF-8'); ?></td>
-                  <td data-order="<?= $venda->valor; ?>"><?= number_format($venda->valor, 2, ',', '.'); ?></td>
+                  <td data-order="<?= $total; ?>"><?= number_format($total, 2, ',', '.'); ?></td>
                 </tr>
                 <?php endforeach; ?>
                 <?php foreach ($saidas as $saida): ?>

--- a/application/views/vendas.php
+++ b/application/views/vendas.php
@@ -45,7 +45,9 @@
             <td><?= $v->cliente; ?></td>
             <td><?= $v->produto; ?></td>
             <td><?= $v->quantidade; ?></td>
-            <td><?= number_format($v->valor, 2, ',', '.'); ?></td>
+            <td data-order="<?= $v->valor * $v->quantidade; ?>">
+              <?= number_format($v->valor * $v->quantidade, 2, ',', '.'); ?>
+            </td>
             <td><button class="btn btn-sm btn-outline-primary imprimir"><i class="bi bi-printer"></i></button></td>
           </tr>
           <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- compute line item totals using quantity in cash flow and sales tables

## Testing
- `php -l application/views/fluxo_caixa.php`
- `php -l application/views/vendas.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6e5d353a0832292bca89aea62aa6b