### PR TITLE
Add admin confirmation workflow for saídas

### DIFF
--- a/application/controllers/Caixa.php
+++ b/application/controllers/Caixa.php
@@ -68,7 +68,7 @@ class Caixa extends MY_Controller {
     public function fluxo()
     {
         $data['vendas'] = $this->Venda_model->todas();
-        $data['saidas'] = $this->Saida_model->all();
+        $data['saidas'] = $this->Saida_model->all('confirmada');
         $this->load->view('fluxo_caixa', $data);
     }
 }

--- a/application/controllers/Saidas.php
+++ b/application/controllers/Saidas.php
@@ -11,6 +11,7 @@ class Saidas extends MY_Controller {
     public function index()
     {
         $data['saidas'] = $this->Saida_model->all();
+        $data['is_admin'] = $this->session->userdata('level') === '1';
         $this->load->view('saidas', $data);
     }
 
@@ -25,17 +26,74 @@ class Saidas extends MY_Controller {
             'data' => $this->input->post('data'),
             'descricao' => $this->input->post('descricao'),
             'valor' => $this->input->post('valor'),
-            'forma_pagamento' => $this->input->post('forma_pagamento')
+            'forma_pagamento' => $this->input->post('forma_pagamento'),
+            'status' => 'pendente'
         ];
 
         if ($this->Saida_model->insert($saida)) {
             $this->output
                 ->set_content_type('application/json')
-                ->set_output(json_encode(['status' => 'success']));
+                ->set_output(json_encode([
+                    'status' => 'success',
+                    'message' => 'Saída registrada e aguardando confirmação do administrador.'
+                ]));
         } else {
             $this->output
                 ->set_content_type('application/json')
-                ->set_output(json_encode(['status' => 'error']));
+                ->set_output(json_encode([
+                    'status' => 'error',
+                    'message' => 'Não foi possível registrar a saída.'
+                ]));
         }
+    }
+
+    public function confirmar($id)
+    {
+        if ($this->session->userdata('level') !== '1') {
+            $this->output
+                ->set_status_header(403)
+                ->set_content_type('application/json')
+                ->set_output(json_encode([
+                    'status' => 'error',
+                    'message' => 'Acesso não autorizado.'
+                ]));
+            return;
+        }
+
+        if ($this->input->method() !== 'post') {
+            $this->output
+                ->set_status_header(405)
+                ->set_content_type('application/json')
+                ->set_output(json_encode([
+                    'status' => 'error',
+                    'message' => 'Método não permitido.'
+                ]));
+            return;
+        }
+
+        $usuario = $this->session->userdata('username');
+        if (empty($usuario)) {
+            $usuario = 'admin';
+        }
+
+        $resultado = $this->Saida_model->confirmar((int) $id, $usuario);
+
+        switch ($resultado) {
+            case 'confirmed':
+                $response = ['status' => 'success', 'message' => 'Saída confirmada com sucesso.'];
+                break;
+            case 'already':
+                $response = ['status' => 'info', 'message' => 'Esta saída já foi confirmada.'];
+                break;
+            case 'not_found':
+                $response = ['status' => 'error', 'message' => 'Saída não encontrada.'];
+                break;
+            default:
+                $response = ['status' => 'error', 'message' => 'Não foi possível confirmar a saída.'];
+        }
+
+        $this->output
+            ->set_content_type('application/json')
+            ->set_output(json_encode($response));
     }
 }

--- a/application/models/Saida_model.php
+++ b/application/models/Saida_model.php
@@ -10,13 +10,54 @@ class Saida_model extends CI_Model {
         $this->load->database();
     }
 
-    public function all()
+    public function all($status = null)
     {
-        return $this->db->order_by('data', 'DESC')->get($this->table)->result();
+        $this->db->order_by('data', 'DESC');
+        if ($status !== null) {
+            $this->db->where('status', $status);
+        }
+
+        return $this->db->get($this->table)->result();
+    }
+
+    public function find($id)
+    {
+        return $this->db->get_where($this->table, ['id' => $id])->row();
     }
 
     public function insert(array $data)
     {
+        if (!isset($data['status'])) {
+            $data['status'] = 'pendente';
+        }
+
         return $this->db->insert($this->table, $data);
+    }
+
+    public function confirmar($id, $usuario)
+    {
+        $saida = $this->find($id);
+
+        if (!$saida) {
+            return 'not_found';
+        }
+
+        if ($saida->status === 'confirmada') {
+            return 'already';
+        }
+
+        $atualizado = $this->db
+            ->where('id', $id)
+            ->update($this->table, [
+                'status' => 'confirmada',
+                'confirmado_por' => $usuario,
+                'confirmado_em' => date('Y-m-d H:i:s'),
+            ]);
+
+        if (!$atualizado) {
+            return 'error';
+        }
+
+        return 'confirmed';
     }
 }

--- a/application/views/nova_saida.php
+++ b/application/views/nova_saida.php
@@ -51,8 +51,8 @@
 
 <div id="toast-success" class="toast align-items-center text-bg-success border-0" role="alert" aria-live="assertive" aria-atomic="true" style="display:none;">
   <div class="d-flex">
-    <div class="toast-body">
-      Saída registrada com sucesso!
+    <div class="toast-body" id="toast-success-message">
+      Saída registrada e aguardando confirmação do administrador.
     </div>
     <button type="button" class="btn-close btn-close-white me-2 m-auto" onclick="hideToast('toast-success')"></button>
   </div>
@@ -60,7 +60,7 @@
 
 <div id="toast-error" class="toast align-items-center text-bg-danger border-0" role="alert" aria-live="assertive" aria-atomic="true" style="display:none;">
   <div class="d-flex">
-    <div class="toast-body">
+    <div class="toast-body" id="toast-error-message">
       Ocorreu um erro ao registrar a saída.
     </div>
     <button type="button" class="btn-close btn-close-white me-2 m-auto" onclick="hideToast('toast-error')"></button>
@@ -90,13 +90,20 @@
     .then(response => response.json())
     .then(data => {
       if (data.status === 'success') {
+        document.getElementById('toast-success-message').textContent = data.message || 'Saída registrada e aguardando confirmação do administrador.';
         showToast('toast-success');
         setTimeout(() => { window.location.href = '<?= site_url('saidas'); ?>'; }, 3000);
       } else {
+        if (data.message) {
+          document.getElementById('toast-error-message').textContent = data.message;
+        }
         showToast('toast-error');
       }
     })
-    .catch(() => showToast('toast-error'));
+    .catch(() => {
+      document.getElementById('toast-error-message').textContent = 'Não foi possível processar o pedido. Tente novamente.';
+      showToast('toast-error');
+    });
   });
 </script>
 </body>

--- a/application/views/saidas.php
+++ b/application/views/saidas.php
@@ -16,6 +16,12 @@
 <div class="content">
   <div class="container mt-5">
     <h3>Saídas</h3>
+    <?php if (!empty($is_admin)): ?>
+      <div class="alert alert-info">Saídas com status <strong>pendente</strong> aguardam sua confirmação.</div>
+    <?php else: ?>
+      <div class="alert alert-warning">As saídas pendentes aguardam confirmação do administrador.</div>
+    <?php endif; ?>
+    <div id="alertPlaceholder"></div>
     <div class="table-responsive">
       <table class="table table-bordered table-striped datatable">
         <thead>
@@ -24,6 +30,8 @@
             <th>Descrição</th>
             <th>Forma de Pagamento</th>
             <th>Valor (Kz)</th>
+            <th>Status</th>
+            <th class="text-center">Ações</th>
           </tr>
         </thead>
         <tbody>
@@ -33,6 +41,28 @@
             <td><?= htmlspecialchars($s->descricao, ENT_QUOTES, 'UTF-8'); ?></td>
             <td><?= htmlspecialchars($s->forma_pagamento, ENT_QUOTES, 'UTF-8'); ?></td>
             <td><?= number_format($s->valor, 2, ',', '.'); ?></td>
+            <td>
+              <?php if ($s->status === 'pendente'): ?>
+                <span class="badge bg-warning text-dark">Pendente</span>
+              <?php else: ?>
+                <span class="badge bg-success">Confirmada</span>
+                <?php if (!empty($s->confirmado_por)): ?>
+                  <div class="small text-muted mt-1">
+                    <?= htmlspecialchars($s->confirmado_por, ENT_QUOTES, 'UTF-8'); ?><br>
+                    <?= $s->confirmado_em ? date('d/m/Y H:i', strtotime($s->confirmado_em)) : ''; ?>
+                  </div>
+                <?php endif; ?>
+              <?php endif; ?>
+            </td>
+            <td class="text-center">
+              <?php if (!empty($is_admin) && $s->status === 'pendente'): ?>
+                <button type="button" class="btn btn-sm btn-success btn-confirmar" data-url="<?= site_url('saidas/confirmar/' . $s->id); ?>">
+                  <i class="bi bi-check2"></i> Confirmar
+                </button>
+              <?php else: ?>
+                <span class="text-muted">—</span>
+              <?php endif; ?>
+            </td>
           </tr>
           <?php endforeach; ?>
         </tbody>
@@ -53,5 +83,55 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/vfs_fonts.js"></script>
 <script src="<?= base_url('assets/tables.js'); ?>"></script>
 <script src="<?= base_url('assets/layout.js'); ?>"></script>
+<script>
+  (function() {
+    const alertPlaceholder = document.getElementById('alertPlaceholder');
+
+    function showAlert(type, message) {
+      const alertType = type === 'success' ? 'success' : (type === 'info' ? 'info' : 'danger');
+      alertPlaceholder.innerHTML = `
+        <div class="alert alert-${alertType} alert-dismissible fade show" role="alert">
+          ${message}
+          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>`;
+    }
+
+    document.querySelectorAll('.btn-confirmar').forEach(button => {
+      button.addEventListener('click', function () {
+        const url = this.getAttribute('data-url');
+        if (!url) {
+          return;
+        }
+
+        if (!confirm('Deseja confirmar esta saída?')) {
+          return;
+        }
+
+        const btn = this;
+        btn.disabled = true;
+
+        fetch(url, {
+          method: 'POST',
+          headers: {
+            'X-Requested-With': 'XMLHttpRequest'
+          }
+        })
+        .then(response => response.json().catch(() => ({ status: 'error', message: 'Resposta inválida do servidor.' })))
+        .then(data => {
+          showAlert(data.status, data.message || '');
+          if (data.status === 'success') {
+            setTimeout(() => window.location.reload(), 1200);
+          } else {
+            btn.disabled = false;
+          }
+        })
+        .catch(() => {
+          showAlert('error', 'Não foi possível confirmar a saída.');
+          btn.disabled = false;
+        });
+      });
+    });
+  })();
+</script>
 </body>
 </html>

--- a/database/saidas.sql
+++ b/database/saidas.sql
@@ -4,6 +4,9 @@ CREATE TABLE `saidas` (
   `descricao` varchar(255) NOT NULL,
   `valor` decimal(10,2) NOT NULL,
   `forma_pagamento` varchar(20) NOT NULL,
+  `status` enum('pendente','confirmada') NOT NULL DEFAULT 'pendente',
+  `confirmado_por` varchar(50) DEFAULT NULL,
+  `confirmado_em` datetime DEFAULT NULL,
   `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
## Summary
- add pending status handling and admin confirmation endpoint for saídas
- show confirmation status in the saídas list with an admin-only action and updated success/error messages when registering
- restrict cash-flow calculations to confirmed records and document the new schema columns for confirmation metadata

## Testing
- php -l application/models/Saida_model.php
- php -l application/controllers/Saidas.php
- php -l application/controllers/Caixa.php
- php -l application/views/saidas.php
- php -l application/views/nova_saida.php

------
https://chatgpt.com/codex/tasks/task_e_68d12604c17c8322a34be382679a4d5d