### PR TITLE
Destacar produtos sem estoque e mais vendidos

### DIFF
--- a/application/controllers/Produtos.php
+++ b/application/controllers/Produtos.php
@@ -11,7 +11,22 @@ class Produtos extends MY_Controller {
 
     public function lista()
     {
-        $data['produtos'] = $this->Produto_model->todos();
+        $produtos = $this->Produto_model->todos();
+        $produtosSemEstoque = $this->Produto_model->fora_de_estoque();
+        $maisVendidos = $this->Produto_model->mais_vendidos();
+
+        $maisVendidosMapa = [];
+        foreach ($maisVendidos as $produto) {
+            $maisVendidosMapa[$produto->id] = (int) $produto->total_vendido;
+        }
+
+        $data = [
+            'produtos' => $produtos,
+            'produtos_sem_estoque' => $produtosSemEstoque,
+            'mais_vendidos' => $maisVendidos,
+            'mais_vendidos_mapa' => $maisVendidosMapa,
+        ];
+
         $this->load->view('lista_produtos', $data);
     }
 

--- a/application/models/Produto_model.php
+++ b/application/models/Produto_model.php
@@ -15,6 +15,35 @@ class Produto_model extends CI_Model {
         return $this->db->get('produtos')->result();
     }
 
+    public function fora_de_estoque() {
+        return $this->db
+            ->where('estoque <=', 0)
+            ->order_by('nome', 'ASC')
+            ->get('produtos')
+            ->result();
+    }
+
+    public function mais_vendidos($limite = 5) {
+        $resultados = $this->db
+            ->select('produtos.id, produtos.nome, produtos.categoria, produtos.preco, produtos.estoque, produtos.imagem, COALESCE(SUM(vendas.quantidade), 0) AS total_vendido', false)
+            ->from('produtos')
+            ->join('vendas', 'vendas.produto = produtos.nome', 'left')
+            ->group_by('produtos.id')
+            ->order_by('total_vendido', 'DESC')
+            ->get()
+            ->result();
+
+        $resultados = array_values(array_filter($resultados, function ($produto) {
+            return (int) $produto->total_vendido > 0;
+        }));
+
+        if ($limite !== NULL) {
+            $resultados = array_slice($resultados, 0, (int) $limite);
+        }
+
+        return $resultados;
+    }
+
     public function buscar_por_nome($nome) {
         return $this->db->get_where('produtos', ['nome' => $nome])->row();
     }


### PR DESCRIPTION
## Summary
- expõe novos dados na listagem para apresentar os produtos fora de estoque e os mais vendidos
- adiciona destaques visuais e filtros rápidos para identificar itens sem estoque e campeões de vendas na tabela
- inclui métodos no modelo de produtos para localizar itens esgotados e calcular os mais vendidos

## Testing
- php -l application/models/Produto_model.php
- php -l application/controllers/Produtos.php
- php -l application/views/lista_produtos.php

------
https://chatgpt.com/codex/tasks/task_e_68d27921c2288322b94abf5f1ffe39de