### PR TITLE
Adiciona quantidade vendida ao destaque de mais vendidos

### DIFF
--- a/application/views/lista_produtos.php
+++ b/application/views/lista_produtos.php
@@ -96,7 +96,11 @@
                     <td>
                       <?= $produto->nome; ?>
                       <?php if ($totalVendido > 0): ?>
-                        <span class="badge bg-success ms-2"><i class="bi bi-star-fill me-1"></i>Mais vendido</span>
+                        <?php $textoQuantidadeVendida = $totalVendido === 1 ? '1 unidade vendida' : $totalVendido . ' unidades vendidas'; ?>
+                        <span class="badge bg-success ms-2">
+                          <i class="bi bi-star-fill me-1"></i>
+                          Mais vendido (<?= $textoQuantidadeVendida; ?>)
+                        </span>
                       <?php endif; ?>
                     </td>
                     <td><?= $produto->categoria; ?></td>


### PR DESCRIPTION
## Summary
- mostrar a quantidade vendida dentro da etiqueta de "Mais vendido" na lista de produtos
- ajustar o texto exibido para diferenciar unidade única de múltiplas unidades vendidas

## Testing
- php -l application/views/lista_produtos.php

------
https://chatgpt.com/codex/tasks/task_e_68d28de6d93c8322b0b6c20d591660ae