### PR TITLE
Adicionar exclusão de vendas restrita ao administrador

### DIFF
--- a/application/controllers/Vendas.php
+++ b/application/controllers/Vendas.php
@@ -11,6 +11,51 @@ class Vendas extends MY_Controller {
     public function index()
     {
         $data['vendas'] = $this->Venda_model->todas();
+        $data['is_admin'] = $this->session->userdata('level') === '1';
         $this->load->view('vendas', $data);
+    }
+
+    public function apagar($id)
+    {
+        if ($this->session->userdata('level') !== '1') {
+            $this->output
+                ->set_status_header(403)
+                ->set_content_type('application/json')
+                ->set_output(json_encode([
+                    'status' => 'error',
+                    'message' => 'Acesso não autorizado.'
+                ]));
+            return;
+        }
+
+        if ($this->input->method() !== 'post') {
+            $this->output
+                ->set_status_header(405)
+                ->set_content_type('application/json')
+                ->set_output(json_encode([
+                    'status' => 'error',
+                    'message' => 'Método não permitido.'
+                ]));
+            return;
+        }
+
+        $resultado = $this->Venda_model->remover((int) $id);
+
+        switch ($resultado) {
+            case 'deleted':
+                $response = ['status' => 'success', 'message' => 'Venda apagada com sucesso.'];
+                break;
+            case 'not_found':
+                $this->output->set_status_header(404);
+                $response = ['status' => 'error', 'message' => 'Venda não encontrada.'];
+                break;
+            default:
+                $this->output->set_status_header(500);
+                $response = ['status' => 'error', 'message' => 'Não foi possível apagar a venda.'];
+        }
+
+        $this->output
+            ->set_content_type('application/json')
+            ->set_output(json_encode($response));
     }
 }

--- a/application/models/Venda_model.php
+++ b/application/models/Venda_model.php
@@ -32,6 +32,29 @@ class Venda_model extends CI_Model {
             ->result();
     }
 
+    public function remover($id)
+    {
+        $venda = $this->db->get_where('vendas', ['id' => $id])->row();
+
+        if (!$venda) {
+            return 'not_found';
+        }
+
+        $this->db->trans_start();
+
+        $this->db->delete('vendas', ['id' => $id]);
+
+        if ((int) $venda->quantidade > 0) {
+            $this->db->set('estoque', 'estoque + ' . (int) $venda->quantidade, false);
+            $this->db->where('nome', $venda->produto);
+            $this->db->update('produtos');
+        }
+
+        $this->db->trans_complete();
+
+        return $this->db->trans_status() ? 'deleted' : false;
+    }
+
     public function por_cliente($cliente)
     {
         return $this->db


### PR DESCRIPTION
## Resumo
- permitir que apenas administradores apaguem vendas por meio de nova ação no controlador
- restaurar o estoque do produto quando uma venda é removida no modelo de vendas
- adicionar botão de exclusão e lógica de confirmação na listagem de vendas para administradores

## Testes
- php -l application/controllers/Vendas.php
- php -l application/models/Venda_model.php

------
https://chatgpt.com/codex/tasks/task_e_68d51db0f2e483228d76ce9e7af3e873