### PR TITLE
Restringe datas futuras em vendas e saídas

### DIFF
--- a/application/controllers/Caixa.php
+++ b/application/controllers/Caixa.php
@@ -26,6 +26,11 @@ class Caixa extends MY_Controller {
         $data_venda = $this->input->post('data');
         $forma_pagamento = $this->input->post('forma_pagamento');
 
+        if (!$this->is_valid_non_future_date($data_venda)) {
+            echo json_encode(['status' => 'error', 'message' => 'A data da venda não pode ser futura.']);
+            return;
+        }
+
         if (!$cliente || !is_array($produtos)) {
             echo json_encode(['status' => 'error', 'message' => 'Cliente ou produtos inválidos']);
             return;

--- a/application/controllers/Saidas.php
+++ b/application/controllers/Saidas.php
@@ -22,8 +22,20 @@ class Saidas extends MY_Controller {
 
     public function salvar()
     {
+        $data_saida = $this->input->post('data');
+
+        if (!$this->is_valid_non_future_date($data_saida)) {
+            $this->output
+                ->set_content_type('application/json')
+                ->set_output(json_encode([
+                    'status' => 'error',
+                    'message' => 'A data da saída não pode ser futura.'
+                ]));
+            return;
+        }
+
         $saida = [
-            'data' => $this->input->post('data'),
+            'data' => $data_saida,
             'descricao' => $this->input->post('descricao'),
             'valor' => $this->input->post('valor'),
             'forma_pagamento' => $this->input->post('forma_pagamento'),

--- a/application/core/MY_Controller.php
+++ b/application/core/MY_Controller.php
@@ -12,4 +12,25 @@ class MY_Controller extends CI_Controller {
             redirect('auth/login');
         }
     }
+
+    /**
+     * Valida se a data informada existe e não está no futuro.
+     */
+    protected function is_valid_non_future_date(?string $date): bool
+    {
+        if (empty($date)) {
+            return false;
+        }
+
+        $dateTime = DateTime::createFromFormat('Y-m-d', $date);
+
+        if (!$dateTime || $dateTime->format('Y-m-d') !== $date) {
+            return false;
+        }
+
+        $today = new DateTime('today');
+        $dateTime->setTime(0, 0, 0);
+
+        return $dateTime <= $today;
+    }
 }


### PR DESCRIPTION
## Summary
- adiciona método utilitário em `MY_Controller` para validar datas não futuras
- impede o registo de vendas e saídas com datas posteriores ao dia actual

## Testing
- php -l application/core/MY_Controller.php
- php -l application/controllers/Caixa.php
- php -l application/controllers/Saidas.php

------
https://chatgpt.com/codex/tasks/task_e_68d65f39dc348322afce73f2646b2083