### PR TITLE
Evita submissão de datas futuras nos formulários

### DIFF
--- a/application/controllers/Caixa.php
+++ b/application/controllers/Caixa.php
@@ -26,6 +26,11 @@ class Caixa extends MY_Controller {
         $data_venda = $this->input->post('data');
         $forma_pagamento = $this->input->post('forma_pagamento');
 
+        if (!$this->is_valid_non_future_date($data_venda)) {
+            echo json_encode(['status' => 'error', 'message' => 'A data da venda não pode ser futura.']);
+            return;
+        }
+
         if (!$cliente || !is_array($produtos)) {
             echo json_encode(['status' => 'error', 'message' => 'Cliente ou produtos inválidos']);
             return;

--- a/application/controllers/Saidas.php
+++ b/application/controllers/Saidas.php
@@ -22,8 +22,20 @@ class Saidas extends MY_Controller {
 
     public function salvar()
     {
+        $data_saida = $this->input->post('data');
+
+        if (!$this->is_valid_non_future_date($data_saida)) {
+            $this->output
+                ->set_content_type('application/json')
+                ->set_output(json_encode([
+                    'status' => 'error',
+                    'message' => 'A data da saída não pode ser futura.'
+                ]));
+            return;
+        }
+
         $saida = [
-            'data' => $this->input->post('data'),
+            'data' => $data_saida,
             'descricao' => $this->input->post('descricao'),
             'valor' => $this->input->post('valor'),
             'forma_pagamento' => $this->input->post('forma_pagamento'),

--- a/application/core/MY_Controller.php
+++ b/application/core/MY_Controller.php
@@ -12,4 +12,25 @@ class MY_Controller extends CI_Controller {
             redirect('auth/login');
         }
     }
+
+    /**
+     * Valida se a data informada existe e não está no futuro.
+     */
+    protected function is_valid_non_future_date(?string $date): bool
+    {
+        if (empty($date)) {
+            return false;
+        }
+
+        $dateTime = DateTime::createFromFormat('Y-m-d', $date);
+
+        if (!$dateTime || $dateTime->format('Y-m-d') !== $date) {
+            return false;
+        }
+
+        $today = new DateTime('today');
+        $dateTime->setTime(0, 0, 0);
+
+        return $dateTime <= $today;
+    }
 }

--- a/application/views/nova_saida.php
+++ b/application/views/nova_saida.php
@@ -80,8 +80,25 @@
     toast.style.display = 'none';
   }
 
-  document.getElementById('saidaForm').addEventListener('submit', function(e) {
+  const saidaForm = document.getElementById('saidaForm');
+  const dataSaidaInput = document.getElementById('dataSaida');
+
+  function isFutureDate(value) {
+    if (!value) {
+      return false;
+    }
+    const selected = new Date(value + 'T00:00:00');
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    return selected > today;
+  }
+
+  saidaForm.addEventListener('submit', function(e) {
     e.preventDefault();
+    if (isFutureDate(dataSaidaInput.value)) {
+      alert('Não é possível registrar uma saída com data futura.');
+      return;
+    }
     const formData = new FormData(this);
     fetch('<?= site_url('saidas/salvar'); ?>', {
       method: 'POST',

--- a/application/views/nova_venda.php
+++ b/application/views/nova_venda.php
@@ -185,8 +185,24 @@
 
       const form = document.getElementById('vendaForm');
       const submitBtn = form.querySelector('button[type="submit"]');
+      const dataInput = document.getElementById('dataVenda');
+
+      function isFutureDate(value) {
+        if (!value) {
+          return false;
+        }
+        const selected = new Date(value + 'T00:00:00');
+        const today = new Date();
+        today.setHours(0, 0, 0, 0);
+        return selected > today;
+      }
+
       form.addEventListener('submit', function(e) {
         e.preventDefault();
+        if (isFutureDate(dataInput.value)) {
+          alert('Não é possível registrar uma venda com data futura.');
+          return;
+        }
         const formData = new FormData(form);
         submitBtn.disabled = true;
         toggleLoading(true);


### PR DESCRIPTION
## Summary
- bloqueia no frontend o envio do formulário de nova venda quando a data selecionada é futura, exibindo alerta ao utilizador
- impede o envio do formulário de nova saída com data futura e avisa através de pop-up

## Testing
- php -l application/views/nova_venda.php
- php -l application/views/nova_saida.php

------
https://chatgpt.com/codex/tasks/task_e_68d65f39dc348322afce73f2646b2083