### PR TITLE
Implementa controle de abertura e fecho do caixa

### DIFF
--- a/application/models/Caixa_periodo_model.php
+++ b/application/models/Caixa_periodo_model.php
@@ -1,0 +1,72 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Caixa_periodo_model extends CI_Model {
+    public function __construct()
+    {
+        parent::__construct();
+        $this->load->database();
+    }
+
+    public function periodo_atual()
+    {
+        return $this->db
+            ->order_by('abertura', 'DESC')
+            ->where('fechamento IS NULL', null, false)
+            ->get('caixa_periodos', 1)
+            ->row();
+    }
+
+    public function todos()
+    {
+        return $this->db
+            ->order_by('abertura', 'DESC')
+            ->get('caixa_periodos')
+            ->result();
+    }
+
+    public function abrir($usuario)
+    {
+        if ($this->periodo_atual()) {
+            return false;
+        }
+
+        $dados = [
+            'abertura' => date('Y-m-d H:i:s'),
+            'usuario_abertura' => $usuario,
+        ];
+
+        if ($this->db->insert('caixa_periodos', $dados)) {
+            return $this->obter($this->db->insert_id());
+        }
+
+        return false;
+    }
+
+    public function fechar($usuario)
+    {
+        $periodo = $this->periodo_atual();
+
+        if (!$periodo) {
+            return false;
+        }
+
+        $dados = [
+            'fechamento' => date('Y-m-d H:i:s'),
+            'usuario_fechamento' => $usuario,
+        ];
+
+        $this->db->where('id', $periodo->id);
+
+        if ($this->db->update('caixa_periodos', $dados)) {
+            return $this->obter($periodo->id);
+        }
+
+        return false;
+    }
+
+    public function obter($id)
+    {
+        return $this->db->get_where('caixa_periodos', ['id' => $id])->row();
+    }
+}

--- a/database/caixa_periodos.sql
+++ b/database/caixa_periodos.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS `caixa_periodos` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `abertura` datetime NOT NULL,
+  `fechamento` datetime DEFAULT NULL,
+  `usuario_abertura` varchar(100) NOT NULL,
+  `usuario_fechamento` varchar(100) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
## Summary
- adiciona modelo de períodos do caixa para registrar aberturas e fechos com horário e usuário responsável
- cria endpoints no controlador de caixa para abertura, fecho e consulta de períodos em formato JSON
- atualiza a tela de fluxo de caixa com painel de status, histórico de períodos e inclui script SQL da nova tabela

## Testing
- php -l application/controllers/Caixa.php
- php -l application/models/Caixa_periodo_model.php

------
https://chatgpt.com/codex/tasks/task_e_68d68c393f388322bf1b2246b34a5053