### PR TITLE
Validate caixa closing totals and persist audit info

### DIFF
--- a/database/caixa_periodos.sql
+++ b/database/caixa_periodos.sql
@@ -4,5 +4,10 @@ CREATE TABLE IF NOT EXISTS `caixa_periodos` (
   `fechamento` datetime DEFAULT NULL,
   `usuario_abertura` varchar(100) NOT NULL,
   `usuario_fechamento` varchar(100) DEFAULT NULL,
+  `total_dinheiro` decimal(15,2) DEFAULT NULL,
+  `total_pos` decimal(15,2) DEFAULT NULL,
+  `total_transferencias` decimal(15,2) DEFAULT NULL,
+  `observacoes_fechamento` text,
+  `confirmacao_responsavel` tinyint(1) DEFAULT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
## Summary
- validate the closing payload in `Caixa::fechar_periodo`, enforcing totals and confirmation before closing the cash register
- persist totals, notes and confirmation when closing a period through `Caixa_periodo_model::fechar`, returning structured success and error responses
- extend the `caixa_periodos` schema and formatter output so period histories expose the recorded reconciliation data

## Testing
- php -l application/controllers/Caixa.php
- php -l application/models/Caixa_periodo_model.php

------
https://chatgpt.com/codex/tasks/task_e_68d6988772288322b5e2df23abe7307c