### PR TITLE
Atualiza totais e confirmações dos períodos de caixa

### DIFF
--- a/application/controllers/Caixa.php
+++ b/application/controllers/Caixa.php
@@ -245,7 +245,7 @@ class Caixa extends MY_Controller {
             'dinheiro' => isset($periodo->total_dinheiro) ? (float) $periodo->total_dinheiro : null,
             'pos' => isset($periodo->total_pos) ? (float) $periodo->total_pos : null,
             'transferencias' => isset($periodo->total_transferencias) ? (float) $periodo->total_transferencias : null,
-            'observacoes' => isset($periodo->observacoes_fechamento) ? $periodo->observacoes_fechamento : null,
+            'observacoes' => isset($periodo->observacoes) ? $periodo->observacoes : null,
             'confirmacao_responsavel' => isset($periodo->confirmacao_responsavel)
                 ? (bool) $periodo->confirmacao_responsavel
                 : null,

--- a/application/migrations/20240518120000_update_caixa_periodos.php
+++ b/application/migrations/20240518120000_update_caixa_periodos.php
@@ -1,0 +1,118 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migration_Update_caixa_periodos extends CI_Migration {
+    public function up()
+    {
+        $this->load->dbforge();
+
+        $decimalColumn = [
+            'type' => 'DECIMAL',
+            'constraint' => '15,2',
+            'null' => FALSE,
+            'default' => '0.00',
+        ];
+
+        foreach (['total_dinheiro', 'total_pos', 'total_transferencias'] as $campo) {
+            if ($this->db->field_exists($campo, 'caixa_periodos')) {
+                $this->dbforge->modify_column('caixa_periodos', [
+                    $campo => $decimalColumn,
+                ]);
+            } else {
+                $this->dbforge->add_column('caixa_periodos', [
+                    $campo => $decimalColumn,
+                ]);
+            }
+        }
+
+        $observacoesColumn = [
+            'type' => 'TEXT',
+            'null' => TRUE,
+        ];
+
+        if ($this->db->field_exists('observacoes_fechamento', 'caixa_periodos')) {
+            $this->dbforge->modify_column('caixa_periodos', [
+                'observacoes_fechamento' => array_merge($observacoesColumn, ['name' => 'observacoes']),
+            ]);
+        } elseif (!$this->db->field_exists('observacoes', 'caixa_periodos')) {
+            $this->dbforge->add_column('caixa_periodos', [
+                'observacoes' => $observacoesColumn,
+            ]);
+        } else {
+            $this->dbforge->modify_column('caixa_periodos', [
+                'observacoes' => $observacoesColumn,
+            ]);
+        }
+
+        $booleanColumn = [
+            'type' => 'TINYINT',
+            'constraint' => 1,
+            'null' => FALSE,
+            'default' => 0,
+        ];
+
+        if ($this->db->field_exists('confirmacao_responsavel', 'caixa_periodos')) {
+            $this->dbforge->modify_column('caixa_periodos', [
+                'confirmacao_responsavel' => $booleanColumn,
+            ]);
+        } else {
+            $this->dbforge->add_column('caixa_periodos', [
+                'confirmacao_responsavel' => $booleanColumn,
+            ]);
+        }
+
+        $this->db->set('total_dinheiro', 0)
+            ->where('total_dinheiro IS NULL', null, false)
+            ->update('caixa_periodos');
+        $this->db->set('total_pos', 0)
+            ->where('total_pos IS NULL', null, false)
+            ->update('caixa_periodos');
+        $this->db->set('total_transferencias', 0)
+            ->where('total_transferencias IS NULL', null, false)
+            ->update('caixa_periodos');
+        $this->db->set('confirmacao_responsavel', 0)
+            ->where('confirmacao_responsavel IS NULL', null, false)
+            ->update('caixa_periodos');
+    }
+
+    public function down()
+    {
+        $this->load->dbforge();
+
+        $decimalNullable = [
+            'type' => 'DECIMAL',
+            'constraint' => '15,2',
+            'null' => TRUE,
+            'default' => NULL,
+        ];
+
+        foreach (['total_dinheiro', 'total_pos', 'total_transferencias'] as $campo) {
+            if ($this->db->field_exists($campo, 'caixa_periodos')) {
+                $this->dbforge->modify_column('caixa_periodos', [
+                    $campo => $decimalNullable,
+                ]);
+            }
+        }
+
+        if ($this->db->field_exists('observacoes', 'caixa_periodos')) {
+            $this->dbforge->modify_column('caixa_periodos', [
+                'observacoes' => [
+                    'name' => 'observacoes_fechamento',
+                    'type' => 'TEXT',
+                    'null' => TRUE,
+                ],
+            ]);
+        }
+
+        if ($this->db->field_exists('confirmacao_responsavel', 'caixa_periodos')) {
+            $this->dbforge->modify_column('caixa_periodos', [
+                'confirmacao_responsavel' => [
+                    'type' => 'TINYINT',
+                    'constraint' => 1,
+                    'null' => TRUE,
+                    'default' => NULL,
+                ],
+            ]);
+        }
+    }
+}

--- a/application/models/Caixa_periodo_model.php
+++ b/application/models/Caixa_periodo_model.php
@@ -34,6 +34,11 @@ class Caixa_periodo_model extends CI_Model {
         $dados = [
             'abertura' => date('Y-m-d H:i:s'),
             'usuario_abertura' => $usuario,
+            'total_dinheiro' => '0.00',
+            'total_pos' => '0.00',
+            'total_transferencias' => '0.00',
+            'observacoes' => null,
+            'confirmacao_responsavel' => 0,
         ];
 
         if ($this->db->insert('caixa_periodos', $dados)) {
@@ -78,10 +83,10 @@ class Caixa_periodo_model extends CI_Model {
         $atualizacao = [
             'fechamento' => date('Y-m-d H:i:s'),
             'usuario_fechamento' => $usuario,
-            'total_dinheiro' => isset($dados['dinheiro']) ? (float) $dados['dinheiro'] : null,
-            'total_pos' => isset($dados['pos']) ? (float) $dados['pos'] : null,
-            'total_transferencias' => isset($dados['transferencias']) ? (float) $dados['transferencias'] : null,
-            'observacoes_fechamento' => isset($dados['observacoes']) ? $dados['observacoes'] : null,
+            'total_dinheiro' => isset($dados['dinheiro']) ? (float) $dados['dinheiro'] : 0,
+            'total_pos' => isset($dados['pos']) ? (float) $dados['pos'] : 0,
+            'total_transferencias' => isset($dados['transferencias']) ? (float) $dados['transferencias'] : 0,
+            'observacoes' => isset($dados['observacoes']) ? $dados['observacoes'] : null,
             'confirmacao_responsavel' => $confirmado ? 1 : 0,
         ];
 

--- a/application/views/fluxo_caixa.php
+++ b/application/views/fluxo_caixa.php
@@ -363,6 +363,7 @@
           pos,
           transferencias,
           observacoes: (inputObservacoes.val() || '').trim(),
+          confirmacao: inputConfirmarResponsavel.is(':checked'),
         };
 
         btnConfirmarFechoCaixa.prop('disabled', true);

--- a/database/caixa_periodos.sql
+++ b/database/caixa_periodos.sql
@@ -4,10 +4,10 @@ CREATE TABLE IF NOT EXISTS `caixa_periodos` (
   `fechamento` datetime DEFAULT NULL,
   `usuario_abertura` varchar(100) NOT NULL,
   `usuario_fechamento` varchar(100) DEFAULT NULL,
-  `total_dinheiro` decimal(15,2) DEFAULT NULL,
-  `total_pos` decimal(15,2) DEFAULT NULL,
-  `total_transferencias` decimal(15,2) DEFAULT NULL,
-  `observacoes_fechamento` text,
-  `confirmacao_responsavel` tinyint(1) DEFAULT NULL,
+  `total_dinheiro` decimal(15,2) NOT NULL DEFAULT '0.00',
+  `total_pos` decimal(15,2) NOT NULL DEFAULT '0.00',
+  `total_transferencias` decimal(15,2) NOT NULL DEFAULT '0.00',
+  `observacoes` text DEFAULT NULL,
+  `confirmacao_responsavel` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
## Summary
- define totais e confirmação do responsável com defaults seguros no schema do caixa e migração dedicada
- ajusta o modelo/controlador para preencher e expor os novos campos ao abrir e fechar períodos
- sincroniza a interface para enviar a confirmação do responsável e manter observações históricas

## Testing
- php -l application/models/Caixa_periodo_model.php
- php -l application/controllers/Caixa.php
- php -l application/migrations/20240518120000_update_caixa_periodos.php

------
https://chatgpt.com/codex/tasks/task_e_68d7f7993ab883229f8bffdd0c68920c